### PR TITLE
core/mvcc: serve cursor reads from the version head before b-tree bytes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7024,7 +7024,7 @@ dependencies = [
 
 [[package]]
 name = "turso-join-benchmark"
-version = "0.8.0-pre.8"
+version = "0.8.0-pre.9"
 dependencies = [
  "anyhow",
  "clap",

--- a/core/mvcc/cursor.rs
+++ b/core/mvcc/cursor.rs
@@ -641,7 +641,36 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> MvccLazyCursor<Clock
         }
         tracing::trace!("current_row({:?})", self.current_pos);
         match &self.current_pos {
-            CursorPosition::Loaded { in_btree: true, .. } => self.btree_cursor.record(),
+            CursorPosition::Loaded { in_btree: true, .. } => {
+                // Read-your-own-write: `insert` deliberately preserves `in_btree`
+                // for the same-row case so checkpointing knows to write deletes
+                // to the b-tree file (see PR #6789). That is the right rule for
+                // *positioning*, but the *read* must consult the version head
+                // first: if this transaction wrote a newer version, the b-tree
+                // bytes are a stale pre-insert/pre-update image (issue #8197).
+                let row_id = match &self.current_pos {
+                    CursorPosition::Loaded { row_id, .. } => row_id.clone(),
+                    _ => unreachable!("matched Loaded above"),
+                };
+                let maybe_index_id = match &self.mv_cursor_type {
+                    MvccCursorType::Index(_) => Some(self.table_id),
+                    MvccCursorType::Table => None,
+                };
+                if let Some(row) =
+                    self.db
+                        .read_from_table_or_index(self.tx_id, &row_id, maybe_index_id)?
+                {
+                    let record = self.get_immutable_record_or_create()?;
+                    record.invalidate();
+                    record.start_serialization(row.payload())?;
+                    let record_ref = self.reusable_immutable_record.as_ref().ok_or_else(|| {
+                        LimboError::InternalError("immutable record not initialized".to_string())
+                    })?;
+                    return Ok(IOResult::Done(Some(record_ref)));
+                }
+                // No visible version: genuinely b-tree-resident, serve the page.
+                self.btree_cursor.record()
+            }
             CursorPosition::Loaded {
                 in_btree: false, ..
             } => {

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -6964,9 +6964,12 @@ fn mvcc_read_your_own_write_after_insert_over_btree_resident_row() {
     let new_record =
         ImmutableRecord::from_values(&[Value::Text(Text::new("NEWVAL_mvcc_v2".to_owned()))], 1)
             .unwrap();
-    cursor
+    let IOResult::Done(_) = cursor
         .insert(&BTreeKey::new_table_rowid(1, Some(&new_record)))
-        .unwrap();
+        .unwrap()
+    else {
+        panic!("unexpected insert result")
+    };
 
     // Read through the same open cursor: must observe the transaction's own
     // write, not the stale b-tree bytes ('OLDVAL_btree_v1').

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -6901,6 +6901,87 @@ fn test_sequence_watermark_reader_never_skips_committed_rows_fuzz() {
     }
 }
 
+/// What this test checks: after a transaction inserts over a b-tree-resident row,
+/// a read through the same open cursor serves the transaction's own write
+/// (read-your-own-write), not the stale pre-insert b-tree bytes.
+/// Why this matters: `MvccLazyCursor::insert` deliberately preserves `in_btree`
+/// for the same-row case (checkpoint delete bookkeeping, PR #6789), but
+/// `current_row()` takes the b-tree branch for `in_btree: true` without
+/// consulting the version head the transaction just wrote — a silent stale
+/// read (issue #8197).
+#[test]
+fn mvcc_read_your_own_write_after_insert_over_btree_resident_row() {
+    let db = MvccTestDb::new();
+    db.conn
+        .execute("CREATE TABLE t(x INTEGER PRIMARY KEY, v TEXT)")
+        .unwrap();
+    db.conn
+        .execute("INSERT INTO t VALUES (1, 'OLDVAL_btree_v1')")
+        .unwrap();
+    // Publish the row into the physical b-tree and collect its MVCC version.
+    db.conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+
+    let root_page = get_rows(
+        &db.conn,
+        "SELECT rootpage FROM sqlite_schema WHERE type = 'table' AND name = 't'",
+    )[0][0]
+        .as_int()
+        .unwrap();
+    let table_id = db.mvcc_store.get_table_id_from_root_page(root_page);
+
+    let tx_id = db
+        .mvcc_store
+        .begin_tx(db.conn.pager.load().clone())
+        .unwrap();
+
+    let mut cursor = MvccLazyCursor::new(
+        db.mvcc_store.clone(),
+        &db.conn,
+        tx_id,
+        i64::from(table_id),
+        MvccCursorType::Table,
+        Box::new(BTreeCursor::new(
+            db.conn.pager.load().clone(),
+            root_page.abs(),
+            1,
+        )),
+    )
+    .unwrap();
+
+    // Equality seek lands the cursor on the b-tree-resident row.
+    let res = cursor
+        .seek(
+            crate::types::SeekKey::TableRowId(1),
+            crate::types::SeekOp::GE { eq_only: true },
+        )
+        .unwrap();
+    let IOResult::Done(_) = res else {
+        panic!("unexpected seek result {res:?}")
+    };
+    assert!(cursor.has_record());
+
+    // The same transaction inserts over the same key with a new value.
+    let new_record =
+        ImmutableRecord::from_values(&[Value::Text(Text::new("NEWVAL_mvcc_v2".to_owned()))], 1)
+            .unwrap();
+    cursor
+        .insert(&BTreeKey::new_table_rowid(1, Some(&new_record)))
+        .unwrap();
+
+    // Read through the same open cursor: must observe the transaction's own
+    // write, not the stale b-tree bytes ('OLDVAL_btree_v1').
+    let served = match cursor.current_row().unwrap() {
+        IOResult::Done(Some(record)) => record,
+        IOResult::Done(None) => panic!("cursor lost its record after insert"),
+        IOResult::IO(io) => panic!("unexpected IO in single-page test db: {io:?}"),
+    };
+    assert_eq!(
+        served.as_blob(),
+        new_record.as_blob(),
+        "cursor served stale pre-insert b-tree bytes (read-your-own-write violation, issue #8197)"
+    );
+}
+
 /// What this test checks: Cursor traversal and seek operations honor MVCC visibility and key ordering under updates/deletes.
 /// Why this matters: Read-path correctness is critical: wrong cursor semantics directly surface as wrong query answers.
 #[test]


### PR DESCRIPTION
Fixes #8197.

## Description

`MvccLazyCursor::insert` deliberately preserves `in_btree` when a transaction inserts over the b-tree-resident row it is positioned on, so checkpointing knows to write deletes to the b-tree file (#6789's residual). `current_row()` trusted that flag and returned `btree_cursor.record()` unconditionally, serving the stale pre-insert b-tree bytes while the transaction's own version sat in the store — a silent read-your-own-write violation, reachable through the insert-over-resident-row path and the equality-only seek fast path (both funnel into the same read).

`current_row()` now consults the version head first and serves the visible version when one exists; it falls back to the b-tree page only when no version is visible. `read_from_table_or_index` returns `None` for genuinely b-tree-resident rows, so the fallback is exact. The positioning rule from #6789 is untouched — only the read path is affected (+31 lines, one hunk).

## Motivation and context

#8197 (read-your-own-write stale read, in-btree cursor) asked whether this still reproduces on `main`. It does: verified on a clean checkout of `c83cac5e0` with the deterministic test in this PR — see the [verification comment](https://github.com/tursodatabase/turso/issues/8197#issuecomment-5587294345) on the issue.

As the issue notes, this shipped without a regression test because #6789 could not construct one; this PR adds it.

## Description of AI Usage

Authored by an AI coding agent (Claude, via the pi harness) under human supervision, per this repo's AI contribution guidelines. The agent: verified the issue's repro on current `main` with a cursor-level regression test (fails pre-fix, passes post-fix), implemented the read-path fix, and ran the validation below. The human reviewer of record is the account owner.

### Validation

- New regression test `mvcc_read_your_own_write_after_insert_over_btree_resident_row`: **fails on `c83cac5e0`** (serves `OLDVAL_btree_v1` bytes), **passes with the fix**.
- `cargo test -p turso_core --lib`: 2382 passed / 0 failed.
- `cargo test -p core_tester --test integration_tests mvcc`: 307 passed / 0 failed.
- `cargo fmt --check` clean; clippy clean for touched code (only pre-existing `core/json/cache.rs:107` warning remains repo-wide).

<!-- allow-edits-from-maintainers enabled via UI -->
