### PR TITLE
Cargo.lock: bump turso-join-benchmark to the workspace version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7024,7 +7024,7 @@ dependencies = [
 
 [[package]]
 name = "turso-join-benchmark"
-version = "0.8.0-pre.8"
+version = "0.8.0-pre.9"
 dependencies = [
  "anyhow",
  "clap",


### PR DESCRIPTION
## Description

Set `turso-join-benchmark` to the workspace version `0.8.0-pre.9` in `Cargo.lock`.

## Motivation and context

The join-benchmark branch was cut before the version bump. Its lock entry kept `0.8.0-pre.8`. Every CI job that passes `--locked` stops immediately.

## Description of AI Usage

Claude Code found the cause and made the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EcSd4ia7Q9mbwcaLoBgK22

---
_Generated by [Claude Code](https://claude.ai/code/session_01EcSd4ia7Q9mbwcaLoBgK22)_