### PR TITLE
bindings/dotnet: validate packaged remote and replica consumers

### DIFF
--- a/.github/workflows/dotnet-publish.yml
+++ b/.github/workflows/dotnet-publish.yml
@@ -435,6 +435,16 @@ jobs:
             exit 1
           fi
 
+          while IFS= read -r package; do
+            package_entries=$(mktemp)
+            unzip -Z1 "$package" > "$package_entries"
+            if grep -Fq "turso_sync_sdk_kit" "$package_entries"; then
+              echo "Internal Rust crate name leaked into $package"
+              exit 1
+            fi
+            rm "$package_entries"
+          done < <(find src -path '*/bin/Release/*.nupkg' -type f)
+
           static_packages=(
             "win-x64:turso_sdk_kit.lib"
             "win-arm64:turso_sdk_kit.lib"
@@ -625,9 +635,211 @@ jobs:
           if ($output -notcontains "Rows: 3") {
             throw "Unexpected NativeAOT sample output: $output"
           }
+          if (-not ($output -match "^Stats revision:")) {
+            throw "NativeAOT sample did not read sync statistics: $output"
+          }
+          foreach ($expectedLine in @("Checkpoint: complete", "Disposed: complete")) {
+            if ($output -notcontains $expectedLine) {
+              throw "NativeAOT sample did not exercise the sync lifecycle ($expectedLine): $output"
+            }
+          }
+
+  validate-android-package:
+    needs: publish
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+
+    defaults:
+      run:
+        working-directory: ${{ env.working-directory }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Install dotnet SDK
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v4
+
+      - name: Install Android workload and NDK
+        shell: bash
+        run: |
+          set -euo pipefail
+          dotnet workload install android
+          sdkmanager --install "ndk;27.2.12479018"
+          echo "ANDROID_NDK_HOME=$ANDROID_HOME/ndk/27.2.12479018" >> "$GITHUB_ENV"
+          echo "ANDROID_NDK_ROOT=$ANDROID_HOME/ndk/27.2.12479018" >> "$GITHUB_ENV"
+
+      - name: Download NuGet packages
+        uses: actions/download-artifact@v7
+        with:
+          name: nuget-packages
+          path: ${{ env.working-directory }}/artifacts/nuget-packages
+
+      - name: Build Android package consumer
+        shell: bash
+        run: |
+          set -euo pipefail
+          package_source=$(realpath artifacts/nuget-packages)
+          nuget_config=samples/MobilePackageConsumer/NuGet.config
+          cat > "$nuget_config" <<EOF
+          <configuration>
+            <packageSources>
+              <clear />
+              <add key="local" value="$package_source" />
+              <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+            </packageSources>
+            <packageSourceMapping>
+              <packageSource key="local">
+                <package pattern="Turso.Data.Sqlite.Provider" />
+                <package pattern="Turso.Data.Common" />
+                <package pattern="Turso.Data.Native" />
+              </packageSource>
+              <packageSource key="nuget.org">
+                <package pattern="*" />
+              </packageSource>
+            </packageSourceMapping>
+          </configuration>
+          EOF
+
+          project=samples/MobilePackageConsumer/Android/AndroidPackageConsumer.csproj
+          dotnet restore "$project" -r android-arm64 --configfile "$nuget_config"
+          dotnet build "$project" -c Release -f net10.0-android -r android-arm64 \
+            --no-restore -t:SignAndroidPackage -p:AndroidPackageFormats=apk
+
+      - name: Verify Android native asset and sync exports
+        shell: bash
+        run: |
+          set -euo pipefail
+          apk=$(find samples/MobilePackageConsumer/Android/bin/Release -name '*-Signed.apk' -print -quit)
+          if [ -z "$apk" ]; then
+            echo "Android package consumer did not produce a signed APK"
+            exit 1
+          fi
+
+          native_entry=lib/arm64-v8a/libturso_sdk_kit.so
+          if ! unzip -Z1 "$apk" | grep -Fxq "$native_entry"; then
+            echo "$apk does not contain $native_entry"
+            exit 1
+          fi
+
+          mkdir -p artifacts/mobile-android
+          unzip -p "$apk" "$native_entry" > artifacts/mobile-android/libturso_sdk_kit.so
+          readelf="$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-readelf"
+          for symbol in \
+            turso_sync_database_new \
+            turso_sync_database_create \
+            turso_sync_database_open \
+            turso_sync_database_connect \
+            turso_sync_database_stats \
+            turso_sync_database_checkpoint \
+            turso_sync_database_deinit
+          do
+            if ! "$readelf" --dyn-syms --wide artifacts/mobile-android/libturso_sdk_kit.so | grep -Eq "[[:space:]]${symbol}$"; then
+              echo "Android package asset does not export $symbol"
+              exit 1
+            fi
+          done
+
+  validate-ios-package:
+    needs: publish
+    runs-on: macos-26
+    timeout-minutes: 30
+    permissions:
+      contents: read
+
+    defaults:
+      run:
+        working-directory: ${{ env.working-directory }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Install dotnet SDK
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Install iOS workload
+        run: dotnet workload install ios
+
+      - name: Download NuGet packages
+        uses: actions/download-artifact@v7
+        with:
+          name: nuget-packages
+          path: ${{ env.working-directory }}/artifacts/nuget-packages
+
+      - name: Build iOS package consumer
+        shell: bash
+        run: |
+          set -euo pipefail
+          package_source=$(realpath artifacts/nuget-packages)
+          nuget_config=samples/MobilePackageConsumer/NuGet.config
+          cat > "$nuget_config" <<EOF
+          <configuration>
+            <packageSources>
+              <clear />
+              <add key="local" value="$package_source" />
+              <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+            </packageSources>
+            <packageSourceMapping>
+              <packageSource key="local">
+                <package pattern="Turso.Data.Sqlite.Provider" />
+                <package pattern="Turso.Data.Common" />
+                <package pattern="Turso.Data.Native" />
+              </packageSource>
+              <packageSource key="nuget.org">
+                <package pattern="*" />
+              </packageSource>
+            </packageSourceMapping>
+          </configuration>
+          EOF
+
+          project=samples/MobilePackageConsumer/iOS/IosPackageConsumer.csproj
+          dotnet restore "$project" -r iossimulator-arm64 --configfile "$nuget_config"
+          dotnet build "$project" -c Release -f net10.0-ios -r iossimulator-arm64 --no-restore \
+            -p:CodesignKey= -p:CodesignProvision=
+
+      - name: Verify iOS native asset and sync exports
+        shell: bash
+        run: |
+          set -euo pipefail
+          app=$(find samples/MobilePackageConsumer/iOS/bin/Release -name '*.app' -type d -print -quit)
+          if [ -z "$app" ]; then
+            echo "iOS package consumer did not produce an app bundle"
+            exit 1
+          fi
+
+          framework="$app/Frameworks/libturso_sdk_kit.framework/libturso_sdk_kit"
+          if [ ! -f "$framework" ]; then
+            echo "$app does not contain the legacy-named libturso_sdk_kit framework"
+            exit 1
+          fi
+
+          for symbol in \
+            turso_sync_database_new \
+            turso_sync_database_create \
+            turso_sync_database_open \
+            turso_sync_database_connect \
+            turso_sync_database_stats \
+            turso_sync_database_checkpoint \
+            turso_sync_database_deinit
+          do
+            if ! nm -gU "$framework" | grep -Eq "[[:space:]]_${symbol}$"; then
+              echo "iOS package asset does not export $symbol"
+              exit 1
+            fi
+          done
 
   publish-to-nuget:
-    needs: validate-nativeaot-static-package
+    needs: [validate-nativeaot-static-package, validate-android-package, validate-ios-package]
     if: ${{ github.event_name == 'workflow_dispatch' && !inputs.skip-publish && !inputs.dry-run }}
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/bindings/dotnet/Directory.Build.props
+++ b/bindings/dotnet/Directory.Build.props
@@ -1,6 +1,7 @@
 <Project>
   <PropertyGroup>
     <Version>0.8.0-pre.9</Version>
+    <TursoPackageVersion>$(Version)</TursoPackageVersion>
     <TursoTargetFrameworks>net8.0;net9.0;net10.0</TursoTargetFrameworks>
     <Company>Turso</Company>
     <Product>Turso</Product>

--- a/bindings/dotnet/samples/MobilePackageConsumer/Android/AndroidManifest.xml
+++ b/bindings/dotnet/samples/MobilePackageConsumer/Android/AndroidManifest.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+  <application android:allowBackup="false" android:label="Turso package consumer" />
+  <uses-permission android:name="android.permission.INTERNET" />
+</manifest>

--- a/bindings/dotnet/samples/MobilePackageConsumer/Android/AndroidPackageConsumer.csproj
+++ b/bindings/dotnet/samples/MobilePackageConsumer/Android/AndroidPackageConsumer.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0-android</TargetFramework>
+    <SupportedOSPlatformVersion>31</SupportedOSPlatformVersion>
+    <OutputType>Exe</OutputType>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <ApplicationId>com.turso.packageconsumer</ApplicationId>
+    <ApplicationVersion>1</ApplicationVersion>
+    <ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>
+    <TrimMode>full</TrimMode>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\..\ReplicaPackageSmoke.cs" Link="ReplicaPackageSmoke.cs" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TursoUseProjectReferences)' != 'true'">
+    <PackageReference Include="Turso.Data.Sqlite.Provider" Version="$(TursoPackageVersion)" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TursoUseProjectReferences)' == 'true'">
+    <ProjectReference Include="..\..\..\src\Turso.Data.Sqlite\Turso.Data.Sqlite.csproj" />
+  </ItemGroup>
+</Project>

--- a/bindings/dotnet/samples/MobilePackageConsumer/Android/MainActivity.cs
+++ b/bindings/dotnet/samples/MobilePackageConsumer/Android/MainActivity.cs
@@ -1,0 +1,20 @@
+using Android.App;
+using Android.OS;
+using Turso.Samples;
+
+namespace Turso.PackageConsumer.Android;
+
+[Activity(Label = "Turso package consumer", MainLauncher = true)]
+public sealed class MainActivity : Activity
+{
+    protected override void OnCreate(Bundle? savedInstanceState)
+    {
+        base.OnCreate(savedInstanceState);
+
+        var directory = FilesDir?.AbsolutePath
+            ?? throw new InvalidOperationException("Android did not provide an application files directory.");
+        var result = ReplicaPackageSmoke.Run(Path.Combine(directory, "replica.db"));
+        if (result.Rows != 3)
+            throw new InvalidOperationException($"Expected 3 rows, got {result.Rows}.");
+    }
+}

--- a/bindings/dotnet/samples/MobilePackageConsumer/README.md
+++ b/bindings/dotnet/samples/MobilePackageConsumer/README.md
@@ -1,0 +1,9 @@
+# Mobile package-consumer validation
+
+These minimal Android and iOS apps consume `Turso.Data.Sqlite.Provider` through its normal NuGet package layering. Their reachable startup path creates an offline embedded replica when needed, opens it, uses the sync connection and statistics APIs, checkpoints, and disposes the native handles.
+
+The `dotnet-publish` workflow builds the Android ARM64 APK and iOS ARM64 simulator app from the packages produced by the same run. It verifies that each application contains the legacy-named `libturso_sdk_kit` native asset and that the asset exports the sync entry points used by the managed code.
+
+CI does not launch either app. Android emulator and iOS simulator execution are intentionally outside this package build/link check.
+
+For a local compile against the current source tree rather than packed artifacts, pass `-p:TursoUseProjectReferences=true`. CI leaves this property unset so it always tests the package dependency chain.

--- a/bindings/dotnet/samples/MobilePackageConsumer/iOS/AppDelegate.cs
+++ b/bindings/dotnet/samples/MobilePackageConsumer/iOS/AppDelegate.cs
@@ -1,0 +1,19 @@
+using Foundation;
+using Turso.Samples;
+using UIKit;
+
+namespace Turso.PackageConsumer.iOS;
+
+[Register("AppDelegate")]
+public sealed class AppDelegate : UIApplicationDelegate
+{
+    public override bool FinishedLaunching(UIApplication application, NSDictionary? launchOptions)
+    {
+        var directory = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+        var result = ReplicaPackageSmoke.Run(Path.Combine(directory, "replica.db"));
+        if (result.Rows != 3)
+            throw new InvalidOperationException($"Expected 3 rows, got {result.Rows}.");
+
+        return true;
+    }
+}

--- a/bindings/dotnet/samples/MobilePackageConsumer/iOS/Info.plist
+++ b/bindings/dotnet/samples/MobilePackageConsumer/iOS/Info.plist
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleDisplayName</key>
+  <string>Turso package consumer</string>
+  <key>CFBundleIdentifier</key>
+  <string>com.turso.packageconsumer</string>
+  <key>CFBundleShortVersionString</key>
+  <string>1.0</string>
+  <key>CFBundleVersion</key>
+  <string>1</string>
+  <key>LSRequiresIPhoneOS</key>
+  <true/>
+  <key>UIDeviceFamily</key>
+  <array>
+    <integer>1</integer>
+    <integer>2</integer>
+  </array>
+</dict>
+</plist>

--- a/bindings/dotnet/samples/MobilePackageConsumer/iOS/IosPackageConsumer.csproj
+++ b/bindings/dotnet/samples/MobilePackageConsumer/iOS/IosPackageConsumer.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0-ios</TargetFramework>
+    <SupportedOSPlatformVersion>13.0</SupportedOSPlatformVersion>
+    <OutputType>Exe</OutputType>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <TrimMode Condition="'$(Configuration)' == 'Release'">full</TrimMode>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\..\ReplicaPackageSmoke.cs" Link="ReplicaPackageSmoke.cs" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TursoUseProjectReferences)' != 'true'">
+    <PackageReference Include="Turso.Data.Sqlite.Provider" Version="$(TursoPackageVersion)" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TursoUseProjectReferences)' == 'true'">
+    <ProjectReference Include="..\..\..\src\Turso.Data.Sqlite\Turso.Data.Sqlite.csproj" />
+  </ItemGroup>
+</Project>

--- a/bindings/dotnet/samples/MobilePackageConsumer/iOS/Main.cs
+++ b/bindings/dotnet/samples/MobilePackageConsumer/iOS/Main.cs
@@ -1,0 +1,4 @@
+using Turso.PackageConsumer.iOS;
+using UIKit;
+
+UIApplication.Main(args, null, typeof(AppDelegate));

--- a/bindings/dotnet/samples/NativeAot/NativeAotSample.csproj
+++ b/bindings/dotnet/samples/NativeAot/NativeAotSample.csproj
@@ -10,10 +10,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Turso.Data.Sqlite.Provider" Version="$(Version)" />
+    <Compile Include="..\ReplicaPackageSmoke.cs" Link="ReplicaPackageSmoke.cs" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TursoUseProjectReferences)' != 'true'">
+    <PackageReference Include="Turso.Data.Sqlite.Provider" Version="$(TursoPackageVersion)" />
     <PackageReference Include="Turso.Data.NativeAot.$(RuntimeIdentifier)"
-                      Version="$(Version)"
+                      Version="$(TursoPackageVersion)"
                       PrivateAssets="all"
                       Condition="'$(PublishAot)' == 'true' and '$(TursoUseStaticNativeLibrary)' == 'true' and '$(RuntimeIdentifier)' != ''" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TursoUseProjectReferences)' == 'true'">
+    <ProjectReference Include="..\..\src\Turso.Data.Sqlite\Turso.Data.Sqlite.csproj" />
   </ItemGroup>
 </Project>

--- a/bindings/dotnet/samples/NativeAot/Program.cs
+++ b/bindings/dotnet/samples/NativeAot/Program.cs
@@ -1,19 +1,17 @@
-using Turso.Data.Sqlite;
+using Turso.Samples;
 
-using var connection = new SqliteConnection("Data Source=:memory:");
-connection.Open();
+var directory = Path.Combine(Path.GetTempPath(), $"turso-nativeaot-{Guid.NewGuid():N}");
+Directory.CreateDirectory(directory);
 
-using (var command = connection.CreateCommand())
+try
 {
-    command.CommandText = """
-        CREATE TABLE items (value TEXT NOT NULL);
-        INSERT INTO items VALUES ('native'), ('aot'), ('turso');
-        """;
-    command.ExecuteNonQuery();
+    var result = ReplicaPackageSmoke.Run(Path.Combine(directory, "replica.db"));
+    Console.WriteLine($"Rows: {result.Rows}");
+    Console.WriteLine($"Stats revision: {result.Revision}");
+    Console.WriteLine("Checkpoint: complete");
+    Console.WriteLine("Disposed: complete");
 }
-
-using (var command = connection.CreateCommand())
+finally
 {
-    command.CommandText = "SELECT COUNT(*) FROM items";
-    Console.WriteLine($"Rows: {command.ExecuteScalar()}");
+    Directory.Delete(directory, recursive: true);
 }

--- a/bindings/dotnet/samples/NativeAot/README.md
+++ b/bindings/dotnet/samples/NativeAot/README.md
@@ -1,12 +1,14 @@
 # Turso NativeAOT sample
 
-This sample publishes a NativeAOT executable that statically links `turso_sdk_kit` from the RID-specific `Turso.Data.NativeAot.*` package:
+This sample publishes a NativeAOT executable that statically links the legacy-named `turso_sdk_kit` library from the RID-specific `Turso.Data.NativeAot.*` package:
 
 ```bash
 dotnet publish -c Release -r win-x64
 ```
 
 Set `<TursoUseStaticNativeLibrary>true</TursoUseStaticNativeLibrary>` with `<PublishAot>true</PublishAot>` and reference the matching `Turso.Data.NativeAot.<rid>` package to enable static native assets. Supported runtime identifiers are `win-x64`, `win-arm64`, `linux-x64`, `linux-arm64`, `osx-x64`, and `osx-arm64`.
+
+The executable creates an offline embedded replica when needed, opens it, connects, writes and reads local data, reads sync statistics, checkpoints, and disposes both the connection and database. This makes NativeAOT publish validate the sync exports rather than only the local database exports.
 
 When using an unreleased local package, add the package output folder as a restore source, for example:
 

--- a/bindings/dotnet/samples/ReplicaPackageSmoke.cs
+++ b/bindings/dotnet/samples/ReplicaPackageSmoke.cs
@@ -1,0 +1,48 @@
+using System.Net;
+using Turso;
+
+namespace Turso.Samples;
+
+internal readonly record struct ReplicaPackageSmokeResult(long Rows, string Revision);
+
+internal static class ReplicaPackageSmoke
+{
+    internal static ReplicaPackageSmokeResult Run(string path)
+    {
+        using var httpClient = new HttpClient(new UnexpectedHttpHandler());
+        var options = new TursoSyncDatabaseOptions(path, new Uri("https://example.invalid"))
+        {
+            BootstrapIfEmpty = false,
+            HttpClient = httpClient,
+        };
+
+        if (!File.Exists(path))
+        {
+            using var created = TursoSyncDatabase.Create(options);
+        }
+
+        using var database = TursoSyncDatabase.Open(options);
+        long rows;
+        using (var connection = database.Connect())
+        {
+            connection.ExecuteNonQuery("CREATE TABLE IF NOT EXISTS items (value TEXT NOT NULL)");
+            connection.ExecuteNonQuery("DELETE FROM items");
+            connection.ExecuteNonQuery("INSERT INTO items VALUES ('native'), ('sync'), ('turso')");
+            using var command = new TursoCommand(connection, "SELECT COUNT(*) FROM items");
+            rows = Convert.ToInt64(command.ExecuteScalar());
+        }
+
+        var stats = database.GetStats();
+        database.Checkpoint();
+        return new ReplicaPackageSmokeResult(rows, stats.Revision);
+    }
+
+    private sealed class UnexpectedHttpHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+            => throw new InvalidOperationException(
+                $"BootstrapIfEmpty=false must not make an HTTP request ({request.Method} {request.RequestUri}).");
+    }
+}


### PR DESCRIPTION
## Summary

This is the final extraction from the closed source draft #8504, based on source commit `04fbd9c8ef690a0126b063626954774ea3b6ceec` and limited to package-consumer validation for the .NET remote/replica support now on `main`.

- update the NativeAOT sample to consume packed packages by default and run an offline replica lifecycle: create when needed, open, connect, query, read stats, checkpoint, and dispose
- add one small shared replica smoke program plus Android ARM64 and iOS ARM64-simulator consumers that compile the same reachable API path with trimming/linking enabled
- add `TursoPackageVersion` as an overridable consumer-package version while leaving the repository version unchanged
- extend `dotnet-publish.yml` to build consumers from the NuGet artifacts produced by the same workflow, inspect APK/app native asset layout, verify required sync exports, and require all consumer checks before an opt-in NuGet publish

## Package identity compatibility

The validation keeps the existing package IDs and public native asset layout unchanged:

- `Turso.Data.Sqlite.Provider`
- `Turso.Data.Common`
- `Turso.Data.Native`
- `Turso.Data.NativeAot.<rid>`
- `runtimes/<rid>/native/turso_sdk_kit.*`
- `runtimes/ios-universal/native/libturso_sdk_kit.xcframework/...`

The workflow also rejects any NuGet package entry containing the internal Rust crate name `turso_sync_sdk_kit`. Android and iOS checks require the legacy `libturso_sdk_kit` filename and verify the replica create/open/connect/stats/checkpoint/deinit exports.

## Validation

- `dotnet format whitespace bindings/dotnet/samples --folder --verify-no-changes`
- built the NativeAOT sample against current project references
- built the Windows x64 sync native library with the `release-official` profile
- locally packed `Turso.Data.Native`, `Turso.Data.Common`, `Turso.Data.Sqlite.Provider`, and `Turso.Data.NativeAot.win-x64` at the unchanged `0.8.0-pre.9` version
- inspected package entries for required managed/native paths, Windows static dependencies, absence of provider-owned runtime assets, and absence of `turso_sync_sdk_kit`
- restored all four packages into a fresh isolated NuGet cache, published the Windows x64 NativeAOT consumer without a dynamic Turso sidecar, and ran it successfully (`Rows: 3`, stats, checkpoint, disposal)
- parsed the updated workflow YAML and checked the diff for whitespace errors

Android APK and iOS simulator app builds, native bundle inspection, and export checks remain CI-only because the mobile workloads are not installed locally.

## Extraction series

This completes the work split out of #8504 after merged PRs #8514, #8516, #8519, #8523, #8530, #8555, #8557, #8609, #8621, #8633, and #8676.