### PR TITLE
whopper: add manual MVCC FTS and rollback scenarios

### DIFF
--- a/testing/concurrent-simulator/Cargo.toml
+++ b/testing/concurrent-simulator/Cargo.toml
@@ -29,6 +29,10 @@ path = "regression_tests.rs"
 name = "regression_tests_cross_platform"
 path = "regression_tests_cross_platform.rs"
 
+[[test]]
+name = "fts_mvcc_scenarios"
+path = "fts_mvcc_scenarios.rs"
+
 [dependencies]
 anyhow.workspace = true
 clap = { workspace = true, features = ["derive"] }

--- a/testing/concurrent-simulator/README.md
+++ b/testing/concurrent-simulator/README.md
@@ -2,6 +2,131 @@
 
 Deterministic concurrent simulator for Turso.
 
+## MVCC full-text search
+
+`fts-mvcc` enables and asserts MVCC, then runs only FTS insert/replace,
+update, delete, MATCH, OPTIMIZE and transaction begin/commit/rollback workloads.
+It uses a reproducible eight-word corpus with 400 competing row IDs and 1–4
+distinct words per document. Thirty percent of probes are adjacent two-word
+phrases. Each probe compares the entire matching ID set and the ordered top
+five against a base-table oracle **in the same SQL statement/snapshot**.
+
+This simulator runs against the FTS implementation in this checkout. It does
+not require the engine changes from the FTS development stack. Ranking checks
+remain enabled by default. Use `--fts-match-only` to diagnose matching and
+snapshot behavior independently: it compares complete ID lists ordered by ID,
+without evaluating FTS scores or limiting the results. This is not a ranking
+validation. `--elle` and `--multiprocess` cannot be combined with this mode.
+
+The ranking oracle does not predict exact BM25 scores. With this corpus each
+queried word occurs once, matching phrase frequency is one, fieldnorms for
+lengths 1–4 are exact, and there are no field boosts. Positive shared BM25
+constants therefore make shorter matching documents rank first. Equal-length
+ties use explicit `id ASC`. Do not add repeated words, long documents, boosts
+or alternate tokenizers without changing the oracle.
+
+The focused database scenarios are manual-only tests in `fts_mvcc_scenarios`.
+They are marked `#[ignore]`, so ordinary test/CI runs do not execute them.
+No CI job selects either FTS mode. Run them explicitly, including the known
+ranking failure:
+
+```sh
+cargo test -p turso_whopper --test fts_mvcc_scenarios -- --ignored --nocapture --test-threads=1
+SEED=12491499896317785285 cargo run -p turso_whopper -- \
+  --mode fts-mvcc --max-connections 6 --max-steps 100000 \
+  --reopen-probability 0.001
+
+SEED=3957 cargo run -p turso_whopper -- \
+  --mode fts-mvcc --fts-match-only --max-connections 6 --max-steps 12000 \
+  --allocation-fault-probability 0 --reopen-probability 0
+```
+
+Increase `--max-steps` for longer stress. Keep the seed, connection count,
+flags and revision to replay a failure. The bounded regression runs three
+12,000-step match-only seeds with six connections and replays the first byte-for-byte;
+it asserts completed token/phrase checks. Separate fixed interleavings keep
+a reader snapshot across a writer's delete/update/insert/OPTIMIZE commit,
+then verify savepoint rollback, full rollback and logical-log reopen, with
+and without ranking checks.
+
+On main revision [554ae1b41](https://github.com/tursodatabase/turso/commit/554ae1b41),
+the ranking regression fails: `alpha bravo` returns IDs `1,2` instead of `2,1`
+even before concurrent writes. The shorter document is ID 2. The match-only
+snapshot/recovery test and all three match-only seeds pass. The ranking test
+still expects the correct order and fails when run explicitly. Like the other
+focused database scenarios, it is excluded from ordinary CI runs. Use the same
+default ranking checks when evaluating later FTS changes.
+
+SimulatorIO delays Completions until `step`; operation scheduling also uses
+the existing yield injector. CLI allocation-failure injection and clean
+reopen are supported. CLI allocation-failure probability defaults to 0.05;
+the bounded library regressions use 0. Set it explicitly for comparisons.
+Cosmic-ray corruption is **not** a recoverable I/O error, and these MVCC runs
+do not use multiprocess or kill modes.
+There is no total-memory bound claim: logical FTS payloads and MVCC versions
+can remain resident. Temporary sorter-file retention in the current simulator
+can also limit long runs; this test-only port does not import the temporary-file
+ownership changes from the FTS stack.
+
+With seed 3957, six connections, allocation-failure probability 0.05 and
+reopen probability 0.001, a 12,000-step match-only run completed 107 checks
+(29 phrases), injected 28 allocation failures and rejected 105 checkpoint
+probes against suspended statements. A 30,000-step run with the same settings
+failed after 248 checks while opening a sorter file at the 1,024-descriptor
+limit. That longer run did not pass; use bounded runs for this baseline.
+
+## Rollback-heavy FTS scenario
+
+`fts-mvcc-rollback` uses one writer (connection 0) and snapshot readers on the
+other connections. The original `fts-mvcc` mode remains the competing-writer
+scenario. Separating the roles lets the rollback sequence complete instead
+of repeatedly aborting on write/merge contention.
+
+Each writer sequence commits an initial document and ensures the second row
+is absent, then starts another concurrent transaction with nested savepoints.
+It updates, inserts and deletes documents, runs `OPTIMIZE` inside both savepoints, and
+checks results after mutations and rollback/release boundaries. Each inner
+rollback, outer rollback and full transaction rollback decision has probability
+0.75. An outer rollback discards the still-open inner savepoint; the writer
+then writes and optimizes again and rolls back to the same outer savepoint
+a second time. A final `OPTIMIZE` is followed by either commit or full rollback.
+
+Two independent checks run at these boundaries: FTS versus a base-text scan,
+and the exact expected IDs/bodies (including absent rows) versus actual table
+contents. Both checks run immediately before and after every `OPTIMIZE`.
+The expected rows catch rollback errors even if FTS and the base table are
+wrong together. Readers repeat one phrase query 2–6 times in a transaction
+and require unchanged results, including when the original result was empty.
+The corpus still satisfies the length-based ranking oracle's assumptions.
+
+The CLI reports successful `OPTIMIZE` statements, row checks, `ROLLBACK TO`,
+`RELEASE`, transaction commits/rollbacks and completed writer scenarios. A
+successful optimize count means the statement finished, not that its enclosing
+transaction committed. A rollback-mode run with no completed writer scenario
+is an error. Unexpected SQL execution errors fail this mode; contention and
+injected OOM abandon the sequence through Whopper's existing transaction error handling.
+
+```sh
+SEED=3957 cargo run -p turso_whopper -- \
+  --mode fts-mvcc-rollback --fts-match-only --max-connections 6 --max-steps 18000 \
+  --allocation-fault-probability 0 --reopen-probability 0
+
+cargo test -p turso_whopper --test fts_mvcc_scenarios fts_rollback -- \
+  --ignored --nocapture --test-threads=1
+```
+
+The manual tests execute all eight inner/outer/full-rollback combinations
+against the database and require completed scenarios, successful optimizes,
+row checks and rollback/release operations in the 18,000-step six-connection run.
+The command above completed two writer scenarios, 212 phrase checks, 9 optimizes
+and 22 row checks, including savepoint and full transaction rollbacks. Add
+`--allocation-fault-probability 0.05 --reopen-probability 0.0001` for fault and
+clean-reopen testing, but do not assume that budget is enough for completion:
+with those flags the run injected 14 allocation failures and completed 205
+phrase checks and 5 optimizes, but no complete writer scenario, so it returned
+an error. Faults and reopen can interrupt every long sequence. These scenarios
+do not simulate process crashes.
+
 ## Coverage
 
 To collect line coverage from actual Whopper execution:

--- a/testing/concurrent-simulator/chaotic_fts.rs
+++ b/testing/concurrent-simulator/chaotic_fts.rs
@@ -1,0 +1,328 @@
+use rand::{Rng, seq::IndexedRandom};
+use rand_chacha::ChaCha8Rng;
+use turso_core::{LimboError, Value};
+
+use crate::chaotic_elle::{ChaoticWorkload, ChaoticWorkloadProfile};
+use crate::operations::{OpResult, Operation, TxMode};
+use crate::properties::Property;
+use crate::workloads::{FTS_SIM_TABLE, FTS_SIM_TOKENS};
+
+pub struct FtsRollbackProfile {
+    pub check_ranking: bool,
+}
+
+impl ChaoticWorkloadProfile for FtsRollbackProfile {
+    fn generate(&self, mut rng: ChaCha8Rng, fiber_id: usize) -> Box<dyn ChaoticWorkload> {
+        let words = FTS_SIM_TOKENS
+            .choose_multiple(&mut rng, 3)
+            .collect::<Vec<_>>();
+        let phrase = format!("{} {}", words[0], words[1]);
+        if fiber_id != 0 {
+            let mut ops = vec![Operation::Begin {
+                mode: TxMode::Concurrent,
+            }];
+            for _ in 0..rng.random_range(2..=6) {
+                ops.push(Operation::FtsMatchDifferential {
+                    token: phrase.clone(),
+                    check_ranking: self.check_ranking,
+                });
+            }
+            ops.push(Operation::Commit);
+            return Box::new(FtsSnapshotReader {
+                ops: ops.into_iter(),
+                snapshot: None,
+            });
+        }
+        let first_id = 1000;
+        let second_id = first_id + 1;
+        let original = format!("{phrase} {}", words[2]);
+        let reversed = format!("{} {}", words[1], words[0]);
+        let baseline = [Some(original.clone()), None];
+        let mut expected = [Some(reversed.clone()), Some(phrase.clone())];
+        let mut ops = vec![
+            Operation::Begin {
+                mode: TxMode::Concurrent,
+            },
+            Operation::Execute {
+                sql: format!(
+                    "INSERT OR REPLACE INTO {FTS_SIM_TABLE} VALUES ({first_id}, '{original}')"
+                ),
+            },
+            Operation::Execute {
+                sql: format!("DELETE FROM {FTS_SIM_TABLE} WHERE id = {second_id}"),
+            },
+            Operation::Commit,
+            Operation::Begin {
+                mode: TxMode::Concurrent,
+            },
+            Operation::Savepoint {
+                name: "fts_outer".into(),
+            },
+            Operation::Execute {
+                sql: format!(
+                    "UPDATE {FTS_SIM_TABLE} SET body = '{reversed}' WHERE id = {first_id}"
+                ),
+            },
+            Operation::Execute {
+                sql: format!("INSERT INTO {FTS_SIM_TABLE} VALUES ({second_id}, '{phrase}')"),
+            },
+        ];
+        let checks = |ops: &mut Vec<Operation>, bodies: &[Option<String>; 2], scenario_complete| {
+            ops.push(Operation::FtsMatchDifferential {
+                token: phrase.clone(),
+                check_ranking: self.check_ranking,
+            });
+            ops.push(Operation::FtsCheckRows {
+                first_id,
+                bodies: bodies.clone(),
+                scenario_complete,
+            });
+        };
+        checks(&mut ops, &expected, false);
+        ops.push(Operation::FtsOptimize);
+        checks(&mut ops, &expected, false);
+        ops.extend([
+            Operation::Savepoint {
+                name: "fts_inner".into(),
+            },
+            Operation::Execute {
+                sql: format!("DELETE FROM {FTS_SIM_TABLE} WHERE id = {first_id}"),
+            },
+            Operation::Execute {
+                sql: format!(
+                    "UPDATE {FTS_SIM_TABLE} SET body = '{}' WHERE id = {second_id}",
+                    words[2]
+                ),
+            },
+        ]);
+        let before_inner = expected.clone();
+        expected = [None, Some(words[2].to_string())];
+        checks(&mut ops, &expected, false);
+        ops.push(Operation::FtsOptimize);
+        checks(&mut ops, &expected, false);
+        if rng.random_bool(0.75) {
+            ops.push(Operation::RollbackToSavepoint {
+                name: "fts_inner".into(),
+            });
+            expected = before_inner;
+            checks(&mut ops, &expected, false);
+        }
+        if rng.random_bool(0.75) {
+            ops.push(Operation::RollbackToSavepoint {
+                name: "fts_outer".into(),
+            });
+            checks(&mut ops, &baseline, false);
+            ops.push(Operation::Execute {
+                sql: format!(
+                    "UPDATE {FTS_SIM_TABLE} SET body = '{reversed}' WHERE id = {first_id}"
+                ),
+            });
+            checks(&mut ops, &[Some(reversed.clone()), None], false);
+            ops.push(Operation::FtsOptimize);
+            checks(&mut ops, &[Some(reversed), None], false);
+            ops.push(Operation::RollbackToSavepoint {
+                name: "fts_outer".into(),
+            });
+            expected.clone_from(&baseline);
+        } else {
+            ops.push(Operation::ReleaseSavepoint {
+                name: "fts_inner".into(),
+            });
+        }
+        ops.push(Operation::ReleaseSavepoint {
+            name: "fts_outer".into(),
+        });
+        checks(&mut ops, &expected, false);
+        ops.push(Operation::FtsOptimize);
+        checks(&mut ops, &expected, false);
+        if rng.random_bool(0.75) {
+            ops.push(Operation::Rollback);
+            expected = baseline;
+        } else {
+            ops.push(Operation::Commit);
+        }
+        checks(&mut ops, &expected, true);
+        Box::new(FtsRollbackWorkload {
+            ops: ops.into_iter(),
+        })
+    }
+}
+
+struct FtsSnapshotReader {
+    ops: std::vec::IntoIter<Operation>,
+    snapshot: Option<Vec<Vec<Value>>>,
+}
+
+impl ChaoticWorkload for FtsSnapshotReader {
+    fn next(&mut self, result: Option<OpResult>) -> Option<Operation> {
+        match result {
+            Some(Err(_)) => return None,
+            Some(Ok(rows)) if !rows.is_empty() => {
+                if let Some(snapshot) = &self.snapshot {
+                    assert_eq!(
+                        &rows, snapshot,
+                        "FTS results changed inside a reader snapshot"
+                    );
+                } else {
+                    self.snapshot = Some(rows);
+                }
+            }
+            _ => {}
+        }
+        self.ops.next()
+    }
+}
+
+struct FtsRollbackWorkload {
+    ops: std::vec::IntoIter<Operation>,
+}
+
+impl ChaoticWorkload for FtsRollbackWorkload {
+    fn next(&mut self, result: Option<OpResult>) -> Option<Operation> {
+        if matches!(result, Some(Err(_))) {
+            return None;
+        }
+        self.ops.next()
+    }
+}
+
+pub struct FtsRollbackProperty;
+
+impl Property for FtsRollbackProperty {
+    fn finish_op(
+        &mut self,
+        step: usize,
+        fiber_id: usize,
+        _txn_id: Option<u64>,
+        _start_exec_id: u64,
+        _end_exec_id: u64,
+        op: &Operation,
+        result: &OpResult,
+    ) -> anyhow::Result<()> {
+        let rows = match result {
+            Ok(rows) => rows,
+            Err(
+                LimboError::Busy
+                | LimboError::BusySnapshot
+                | LimboError::WriteWriteConflict
+                | LimboError::CommitDependencyAborted
+                | LimboError::OutOfMemory,
+            ) => return Ok(()),
+            Err(error) => anyhow::bail!(
+                "step {step} fiber {fiber_id}: FTS rollback operation {op:?} failed: {error}"
+            ),
+        };
+        let Operation::FtsCheckRows {
+            first_id, bodies, ..
+        } = op
+        else {
+            return Ok(());
+        };
+        let expected = bodies
+            .iter()
+            .enumerate()
+            .filter_map(|(offset, body)| {
+                body.as_ref().map(|body| {
+                    vec![
+                        Value::from_i64(first_id + offset as i64),
+                        Value::build_text(body.clone()),
+                    ]
+                })
+            })
+            .collect::<Vec<_>>();
+        anyhow::ensure!(
+            rows == &expected,
+            "step {step} fiber {fiber_id}: FTS rollback rows disagree: expected {expected:?}, got {rows:?}"
+        );
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand::SeedableRng;
+
+    #[test]
+    fn every_optimize_has_matching_checks_before_and_after() {
+        for seed in 0..100 {
+            let mut plan = FtsRollbackProfile {
+                check_ranking: false,
+            }
+            .generate(ChaCha8Rng::seed_from_u64(seed), 0);
+            let mut ops = Vec::new();
+            let mut result = None;
+            while let Some(op) = plan.next(result.take()) {
+                ops.push(op);
+                result = Some(Ok(vec![]));
+            }
+            let mut optimizes = 0;
+            for (i, op) in ops.iter().enumerate() {
+                if !matches!(op, Operation::FtsOptimize) {
+                    continue;
+                }
+                optimizes += 1;
+                assert!(matches!(ops[i - 2], Operation::FtsMatchDifferential { .. }));
+                assert!(matches!(ops[i + 1], Operation::FtsMatchDifferential { .. }));
+                let Operation::FtsCheckRows { bodies: before, .. } = &ops[i - 1] else {
+                    panic!("missing row check before OPTIMIZE");
+                };
+                let Operation::FtsCheckRows { bodies: after, .. } = &ops[i + 2] else {
+                    panic!("missing row check after OPTIMIZE");
+                };
+                assert_eq!(before, after);
+            }
+            assert!(optimizes >= 3);
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "FTS results changed inside a reader snapshot")]
+    fn reader_rejects_a_changed_snapshot() {
+        let mut reader = FtsRollbackProfile {
+            check_ranking: false,
+        }
+        .generate(ChaCha8Rng::seed_from_u64(7), 1);
+        reader.next(None);
+        reader.next(Some(Ok(vec![])));
+        reader.next(Some(Ok(vec![vec![Value::Null]])));
+        reader.next(Some(Ok(vec![vec![Value::build_text("1000")]])));
+    }
+
+    #[test]
+    fn failed_operation_abandons_savepoint_sequence() {
+        let profile = FtsRollbackProfile {
+            check_ranking: false,
+        };
+        let mut workload = profile.generate(ChaCha8Rng::seed_from_u64(7), 0);
+        assert!(matches!(workload.next(None), Some(Operation::Begin { .. })));
+        assert!(workload.next(Some(Err(LimboError::OutOfMemory))).is_none());
+    }
+
+    #[test]
+    fn row_check_rejects_unrolled_back_insert_and_wrong_body() {
+        let op = Operation::FtsCheckRows {
+            first_id: 1000,
+            bodies: [Some("alpha bravo".into()), None],
+            scenario_complete: false,
+        };
+        let row = vec![Value::from_i64(1000), Value::build_text("alpha bravo")];
+        let check = |rows| FtsRollbackProperty.finish_op(0, 0, None, 0, 0, &op, &Ok(rows));
+        assert!(check(vec![row.clone()]).is_ok());
+        assert!(check(vec![]).is_err());
+        assert!(
+            check(vec![vec![
+                Value::from_i64(1000),
+                Value::build_text("bravo alpha")
+            ]])
+            .is_err()
+        );
+        assert!(
+            check(vec![
+                row,
+                vec![Value::from_i64(1001), Value::build_text("alpha bravo")]
+            ])
+            .is_err()
+        );
+    }
+}

--- a/testing/concurrent-simulator/fts_mvcc_scenarios.rs
+++ b/testing/concurrent-simulator/fts_mvcc_scenarios.rs
@@ -1,0 +1,256 @@
+use rand_chacha::{ChaCha8Rng, rand_core::SeedableRng};
+use std::sync::Arc;
+use turso_core::{Database, DatabaseOpts, IO, OpenFlags, SqliteDialect, Value};
+use turso_whopper::chaotic_elle::ChaoticWorkloadProfile;
+use turso_whopper::chaotic_fts::{FtsRollbackProfile, FtsRollbackProperty};
+use turso_whopper::operations::Operation;
+use turso_whopper::properties::{FtsSelfDifferentialProperty, IntegrityCheckProperty, Property};
+use turso_whopper::workloads::{fts_sim_schema, fts_sim_workloads};
+use turso_whopper::{IOFaultConfig, SimulatorIO, Whopper, WhopperOpts};
+
+#[test]
+#[ignore = "manual FTS/MVCC baseline; not enabled in CI"]
+fn fts_match_seeds_replay() {
+    let run = |seed| {
+        let mut whopper = Whopper::new(WhopperOpts {
+            seed: Some(seed),
+            max_connections: 6,
+            max_steps: 12_000,
+            enable_mvcc: true,
+            elle_tables: fts_sim_schema(),
+            workloads: fts_sim_workloads(false),
+            properties: vec![
+                Box::new(IntegrityCheckProperty),
+                Box::new(FtsSelfDifferentialProperty),
+            ],
+            ..WhopperOpts::default()
+        })
+        .unwrap();
+        whopper.run().unwrap();
+        assert!(whopper.stats.fts_checks > 0 && whopper.stats.fts_phrase_checks > 0);
+        assert!(whopper.stats.fts_optimizes > 0);
+        eprintln!("seed={seed}: {:?}", whopper.stats);
+        (whopper.stats.clone(), whopper.db_file_bytes())
+    };
+    let (first, files) = run(0xF75);
+    let (second, replay) = run(0xF75);
+    assert_eq!(first.fts_checks, second.fts_checks);
+    assert_eq!(first.fts_phrase_checks, second.fts_phrase_checks);
+    assert!(!files.is_empty());
+    assert_eq!(files, replay);
+    for seed in [0xF7501, 0xF7502] {
+        run(seed);
+    }
+}
+
+#[test]
+#[ignore = "manual FTS/MVCC baseline; not enabled in CI"]
+fn fts_rollback_interleavings() {
+    let mut whopper = Whopper::new(WhopperOpts {
+        seed: Some(3957),
+        max_connections: 6,
+        max_steps: 18_000,
+        enable_mvcc: true,
+        elle_tables: fts_sim_schema(),
+        workloads: vec![],
+        chaotic_profiles: vec![(
+            1.0,
+            "fts-rollback",
+            Box::new(FtsRollbackProfile {
+                check_ranking: false,
+            }),
+        )],
+        properties: vec![
+            Box::new(IntegrityCheckProperty),
+            Box::new(FtsSelfDifferentialProperty),
+            Box::new(FtsRollbackProperty),
+        ],
+        ..WhopperOpts::default()
+    })
+    .unwrap();
+    whopper.run().unwrap();
+    let stats = &whopper.stats;
+    eprintln!("{stats:?}");
+    assert!(stats.fts_rollback_scenarios > 0);
+    assert!(stats.fts_optimizes > 0 && stats.fts_row_checks > 0);
+    assert!(stats.savepoint_rollbacks > 0 && stats.savepoint_releases > 0);
+    assert!(stats.commits > 0 && stats.rollbacks > 0);
+}
+
+#[test]
+#[ignore = "manual FTS/MVCC baseline; not enabled in CI"]
+fn fts_rollback_all_savepoint_and_transaction_outcomes() {
+    let profile = FtsRollbackProfile {
+        check_ranking: false,
+    };
+    let mut covered = [false; 8];
+    for seed in 0..512 {
+        let mut plan = profile.generate(ChaCha8Rng::seed_from_u64(seed), 0);
+        let mut ops = Vec::new();
+        let mut result = None;
+        while let Some(op) = plan.next(result.take()) {
+            ops.push(op);
+            result = Some(Ok(vec![]));
+        }
+        let inner = ops
+            .iter()
+            .any(|op| matches!(op, Operation::RollbackToSavepoint { name } if name == "fts_inner"));
+        let outer = ops
+            .iter()
+            .any(|op| matches!(op, Operation::RollbackToSavepoint { name } if name == "fts_outer"));
+        let rollback = ops.iter().any(|op| matches!(op, Operation::Rollback));
+        let combination =
+            usize::from(inner) | (usize::from(outer) << 1) | (usize::from(rollback) << 2);
+        if covered[combination] {
+            continue;
+        }
+        let io = Arc::new(SimulatorIO::new(
+            false,
+            ChaCha8Rng::seed_from_u64(seed),
+            IOFaultConfig::default(),
+        ));
+        let db = open(&io, &format!("fts-outcomes-{seed}"));
+        let conn = db.connect().unwrap();
+        conn.execute("PRAGMA journal_mode = 'mvcc'").unwrap();
+        assert!(db.get_mv_store().is_some());
+        for (_, sql) in fts_sim_schema() {
+            conn.execute(sql).unwrap();
+        }
+        for (step, op) in ops.iter().enumerate() {
+            let rows = execute(&conn, &io, &op.sql());
+            FtsRollbackProperty
+                .finish_op(step, 0, None, 0, 0, op, &Ok(rows.clone()))
+                .unwrap();
+            FtsSelfDifferentialProperty
+                .finish_op(step, 0, None, 0, 0, op, &Ok(rows))
+                .unwrap();
+        }
+        assert!(matches!(
+            ops.last(),
+            Some(Operation::FtsCheckRows {
+                scenario_complete: true,
+                ..
+            })
+        ));
+        eprintln!(
+            "seed={seed}: inner_rollback={inner}, outer_rollback={outer}, full_rollback={rollback}"
+        );
+        covered[combination] = true;
+        if covered.iter().all(|covered| *covered) {
+            break;
+        }
+    }
+    assert!(
+        covered.iter().all(|covered| *covered),
+        "missing outcomes: {covered:?}"
+    );
+}
+
+#[test]
+#[ignore = "manual FTS/MVCC baseline; not enabled in CI"]
+fn fts_snapshot_merge_savepoint_and_recovery() {
+    snapshot_merge_savepoint_and_recovery(false);
+}
+
+#[test]
+#[ignore = "manual FTS/MVCC ranking baseline; currently fails on main; not enabled in CI"]
+fn fts_ranking_snapshot_merge_savepoint_and_recovery() {
+    snapshot_merge_savepoint_and_recovery(true);
+}
+
+fn snapshot_merge_savepoint_and_recovery(check_ranking: bool) {
+    let io = Arc::new(SimulatorIO::new(
+        false,
+        ChaCha8Rng::seed_from_u64(0xF7502),
+        IOFaultConfig::default(),
+    ));
+    let name = format!("fts-snapshot-{check_ranking}");
+    let db = open(&io, &name);
+    let writer = db.connect().unwrap();
+    writer.execute("PRAGMA journal_mode = 'mvcc'").unwrap();
+    assert!(db.get_mv_store().is_some());
+    for (_, sql) in fts_sim_schema() {
+        writer.execute(sql).unwrap();
+    }
+    writer.execute("INSERT INTO fts_docs VALUES (1, 'alpha bravo hotel'), (2, 'alpha bravo'), (3, 'bravo alpha'), (4, 'delta')").unwrap();
+    let reader = db.connect().unwrap();
+    reader.execute("BEGIN CONCURRENT").unwrap();
+    let check = |conn: &Arc<turso_core::Connection>, expected: &str| {
+        let op = Operation::FtsMatchDifferential {
+            token: "alpha bravo".into(),
+            check_ranking,
+        };
+        let rows = execute(conn, &io, &op.sql());
+        assert_eq!(rows[0][4].to_string(), expected);
+        FtsSelfDifferentialProperty
+            .finish_op(0, 0, None, 0, 0, &op, &Ok(rows))
+            .unwrap();
+    };
+    let initial = if check_ranking { "2,1" } else { "1,2" };
+    check(&reader, initial);
+    for sql in [
+        "BEGIN CONCURRENT",
+        "DELETE FROM fts_docs WHERE id = 2",
+        "UPDATE fts_docs SET body = 'delta' WHERE id = 1",
+        "INSERT INTO fts_docs VALUES (5, 'alpha bravo')",
+        "OPTIMIZE INDEX fts_docs_fts",
+        "COMMIT",
+    ] {
+        writer.execute(sql).unwrap();
+    }
+    check(&reader, initial);
+    check(&writer, "5");
+    for sql in [
+        "BEGIN CONCURRENT",
+        "SAVEPOINT edit",
+        "DELETE FROM fts_docs WHERE id = 5",
+        "ROLLBACK TO edit",
+        "RELEASE edit",
+    ] {
+        writer.execute(sql).unwrap();
+    }
+    check(&writer, "5");
+    writer
+        .execute("INSERT INTO fts_docs VALUES (6, 'alpha bravo')")
+        .unwrap();
+    writer.execute("ROLLBACK").unwrap();
+    check(&writer, "5");
+    reader.execute("COMMIT").unwrap();
+    drop(reader);
+    drop(writer);
+    drop(db);
+    let recovered = open(&io, &name);
+    assert!(recovered.get_mv_store().is_some());
+    check(&recovered.connect().unwrap(), "5");
+}
+
+fn open(io: &Arc<SimulatorIO>, name: &str) -> Arc<Database> {
+    let path = std::env::current_dir()
+        .unwrap()
+        .join(format!("{name}-{}.db", std::process::id()));
+    Database::open_file_with_flags(
+        io.clone(),
+        path.to_str().unwrap(),
+        OpenFlags::default(),
+        DatabaseOpts::new().with_index_method(true),
+        None,
+        Arc::new(SqliteDialect),
+    )
+    .unwrap()
+}
+
+fn execute(conn: &Arc<turso_core::Connection>, io: &SimulatorIO, sql: &str) -> Vec<Vec<Value>> {
+    let mut stmt = conn.prepare(sql).unwrap();
+    let mut rows = Vec::new();
+    loop {
+        match stmt.step().unwrap() {
+            turso_core::StepResult::Row => {
+                rows.push(stmt.row().unwrap().get_values().cloned().collect())
+            }
+            turso_core::StepResult::IO => io.step().unwrap(),
+            turso_core::StepResult::Yield => {}
+            turso_core::StepResult::Done => return rows,
+            other => panic!("unexpected {other:?}"),
+        }
+    }
+}

--- a/testing/concurrent-simulator/lib.rs
+++ b/testing/concurrent-simulator/lib.rs
@@ -29,6 +29,7 @@ use turso_parser::ast::{ColumnConstraint, SortOrder};
 mod allocation_fault;
 pub mod chaotic_btree;
 pub mod chaotic_elle;
+pub mod chaotic_fts;
 pub mod elle;
 pub mod error_handling;
 mod io;
@@ -558,6 +559,14 @@ pub struct Stats {
     pub sequence_nextvals: usize,
     /// FTS self-differential checks that ran to completion
     pub fts_checks: usize,
+    pub fts_phrase_checks: usize,
+    pub fts_optimizes: usize,
+    pub fts_row_checks: usize,
+    pub fts_rollback_scenarios: usize,
+    pub savepoint_rollbacks: usize,
+    pub savepoint_releases: usize,
+    pub commits: usize,
+    pub rollbacks: usize,
     /// Same-connection checkpoint probes fired against suspended statements
     pub checkpoint_probes: usize,
 }
@@ -767,6 +776,10 @@ impl Whopper {
         // Enable MVCC if requested
         if opts.enable_mvcc {
             bootstrap_conn.execute("PRAGMA journal_mode = 'mvcc'")?;
+            assert!(
+                db.get_mv_store().is_some(),
+                "MVCC workload needs an MVCC store"
+            );
         }
 
         let schema = create_initial_schema(&mut rng, &opts.schema_bias);

--- a/testing/concurrent-simulator/main.rs
+++ b/testing/concurrent-simulator/main.rs
@@ -11,6 +11,7 @@ use turso_whopper::{
     StepResult, Whopper, WhopperOpts,
     chaotic_btree::BtreeRebalanceProfile,
     chaotic_elle::{ChaoticElleProfile, ChaoticWorkloadProfile, ElleModelKind},
+    chaotic_fts::{FtsRollbackProfile, FtsRollbackProperty},
     properties::*,
     workloads::*,
 };
@@ -31,9 +32,11 @@ struct Args {
     #[command(subcommand)]
     subcommand: Option<SubCmd>,
 
-    /// Simulation mode (fast, chaos, schema-clone-faults, btree-rebalance/btree-rekey, recovery-heavy, ragnarök/ragnarok)
+    /// Simulation mode (fast, fts-mvcc, fts-mvcc-rollback, chaos, schema-clone-faults, btree-rebalance/btree-rekey, recovery-heavy, ragnarök/ragnarok)
     #[arg(long, default_value = "fast")]
     mode: String,
+    #[arg(long, help = "Check FTS matching without ranking (FTS modes only)")]
+    fts_match_only: bool,
     /// Max connections
     #[arg(long, default_value_t = 4)]
     max_connections: usize,
@@ -156,13 +159,15 @@ fn main() -> anyhow::Result<()> {
             rng.next_u64()
         });
 
-    if args.enable_experimental_mvcc_passive_checkpoint && !args.enable_mvcc {
+    validate_fts_args(&args)?;
+    let enable_mvcc = args.enable_mvcc || is_fts_mode(&args.mode);
+    if args.enable_experimental_mvcc_passive_checkpoint && !enable_mvcc {
         return Err(anyhow::anyhow!(
             "--enable-experimental-mvcc-passive-checkpoint requires --enable-mvcc"
         ));
     }
 
-    if args.mvcc_checkpoint_threshold.is_some() && !args.enable_mvcc {
+    if args.mvcc_checkpoint_threshold.is_some() && !enable_mvcc {
         return Err(anyhow::anyhow!(
             "--mvcc-checkpoint-threshold requires --enable-mvcc"
         ));
@@ -345,6 +350,27 @@ fn run_inprocess(args: &Args, seed: u64) -> anyhow::Result<()> {
     }
     prop_result?;
 
+    if whopper.stats.fts_checks > 0 {
+        println!(
+            "\n{} FTS oracle checks completed ({} phrase checks)",
+            whopper.stats.fts_checks, whopper.stats.fts_phrase_checks
+        );
+    }
+
+    if is_fts_mode(&args.mode) {
+        let stats = &whopper.stats;
+        println!(
+            "FTS: {} successful OPTIMIZE statements, {} row checks, {} completed rollback scenarios; {} ROLLBACK TO, {} RELEASE, {} COMMIT, {} ROLLBACK",
+            stats.fts_optimizes,
+            stats.fts_row_checks,
+            stats.fts_rollback_scenarios,
+            stats.savepoint_rollbacks,
+            stats.savepoint_releases,
+            stats.commits,
+            stats.rollbacks
+        );
+    }
+
     let allocation_faults = whopper.allocation_fault_count();
     if allocation_faults > 0 {
         println!("\n{allocation_faults} allocation faults injected");
@@ -359,6 +385,13 @@ fn run_inprocess(args: &Args, seed: u64) -> anyhow::Result<()> {
 
     if args.elle.is_some() {
         println!("\nElle history exported to: {}", args.elle_output);
+    }
+
+    if args.mode == "fts-mvcc-rollback" {
+        anyhow::ensure!(
+            whopper.stats.fts_rollback_scenarios > 0,
+            "no FTS rollback scenario completed"
+        );
     }
 
     Ok(())
@@ -451,6 +484,25 @@ fn build_workloads_and_properties(args: &Args) -> BuildArtifacts {
         let p: Vec<Box<dyn Property>> = vec![Box::new(IntegrityCheckProperty)];
 
         (w, p, vec![], vec![])
+    } else if is_fts_mode(&args.mode) {
+        let mut properties: PropertyList = vec![
+            Box::new(IntegrityCheckProperty),
+            Box::new(FtsSelfDifferentialProperty),
+        ];
+        let mut chaotic: ChaosProfiles = vec![];
+        let mut workloads = fts_sim_workloads(!args.fts_match_only);
+        if args.mode == "fts-mvcc-rollback" {
+            workloads.clear();
+            properties.push(Box::new(FtsRollbackProperty));
+            chaotic.push((
+                1.0,
+                "fts-rollback",
+                Box::new(FtsRollbackProfile {
+                    check_ranking: !args.fts_match_only,
+                }),
+            ));
+        }
+        (workloads, properties, fts_sim_schema(), chaotic)
     } else {
         let allow_passive_checkpoint =
             !args.enable_mvcc || args.enable_experimental_mvcc_passive_checkpoint;
@@ -482,7 +534,13 @@ fn build_workloads_and_properties(args: &Args) -> BuildArtifacts {
             (12, Box::new(FtsInsertWorkload)),
             (8, Box::new(FtsUpdateWorkload)),
             (6, Box::new(FtsDeleteWorkload)),
-            (10, Box::new(FtsMatchWorkload)),
+            (
+                10,
+                Box::new(FtsMatchWorkload {
+                    check_ranking: false,
+                    phrases: false,
+                }),
+            ),
             (2, Box::new(FtsOptimizeWorkload)),
             (30, Box::new(BeginWorkload)),
             (10, Box::new(CommitWorkload)),
@@ -509,8 +567,9 @@ type ChaosProfiles = Vec<(f64, &'static str, Box<dyn ChaoticWorkloadProfile>)>;
 type BuildArtifacts = (WorkerWorkloads, PropertyList, TableSchemas, ChaosProfiles);
 
 fn build_inprocess_opts(args: &Args, seed: u64) -> anyhow::Result<WhopperOpts> {
+    validate_fts_args(args)?;
     let mut base_opts = match args.mode.as_str() {
-        "fast" => WhopperOpts::fast(),
+        "fast" | "fts-mvcc" | "fts-mvcc-rollback" => WhopperOpts::fast(),
         "chaos" => WhopperOpts::chaos(),
         "schema-clone-faults" => WhopperOpts::schema_clone_faults(),
         "btree-rebalance" | "btree-rekey" => WhopperOpts::btree_rebalance(),
@@ -533,7 +592,9 @@ fn build_inprocess_opts(args: &Args, seed: u64) -> anyhow::Result<WhopperOpts> {
         .with_seed(seed)
         .with_max_connections(args.max_connections)
         .with_keep_files(args.keep)
-        .with_enable_mvcc(args.enable_mvcc || is_schema_clone_fault_mode(&args.mode))
+        .with_enable_mvcc(
+            args.enable_mvcc || is_fts_mode(&args.mode) || is_schema_clone_fault_mode(&args.mode),
+        )
         .with_experimental_mvcc_passive_checkpoint(args.enable_experimental_mvcc_passive_checkpoint)
         .with_mvcc_checkpoint_threshold(args.mvcc_checkpoint_threshold)
         .with_enable_encryption(args.enable_encryption)
@@ -550,8 +611,24 @@ fn build_inprocess_opts(args: &Args, seed: u64) -> anyhow::Result<WhopperOpts> {
     Ok(opts)
 }
 
+fn validate_fts_args(args: &Args) -> anyhow::Result<()> {
+    anyhow::ensure!(
+        !args.fts_match_only || is_fts_mode(&args.mode),
+        "--fts-match-only requires an FTS mode"
+    );
+    anyhow::ensure!(
+        !is_fts_mode(&args.mode) || (!args.multiprocess && args.elle.is_none()),
+        "FTS modes require in-process FTS workloads; do not combine them with --multiprocess or --elle"
+    );
+    Ok(())
+}
+
 fn is_btree_rebalance_mode(mode: &str) -> bool {
     matches!(mode, "btree-rebalance" | "btree-rekey")
+}
+
+fn is_fts_mode(mode: &str) -> bool {
+    matches!(mode, "fts-mvcc" | "fts-mvcc-rollback")
 }
 
 fn is_schema_clone_fault_mode(mode: &str) -> bool {
@@ -610,4 +687,38 @@ fn init_logger() {
                 .unwrap_or_else(|_| EnvFilter::new("info,tantivy=warn")),
         )
         .try_init();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fts_mode_enables_mvcc_and_keeps_ranking_enabled_by_default() {
+        for mode in ["fts-mvcc", "fts-mvcc-rollback"] {
+            let args = Args::parse_from(["whopper", "--mode", mode]);
+            let opts = build_inprocess_opts(&args, 3957).unwrap();
+            assert!(opts.enable_mvcc);
+            assert!(!args.fts_match_only);
+            assert_eq!(opts.elle_tables, fts_sim_schema());
+            assert_eq!(opts.workloads.is_empty(), mode == "fts-mvcc-rollback");
+            assert_eq!(
+                opts.chaotic_profiles.len(),
+                usize::from(mode == "fts-mvcc-rollback")
+            );
+        }
+    }
+
+    #[test]
+    fn fts_mode_rejects_options_that_replace_its_workload() {
+        for mode in ["fts-mvcc", "fts-mvcc-rollback"] {
+            for extra in [vec!["--multiprocess"], vec!["--elle", "list-append"]] {
+                let mut argv = vec!["whopper", "--mode", mode];
+                argv.extend(extra);
+                assert!(build_inprocess_opts(&Args::parse_from(argv), 3957).is_err());
+            }
+        }
+        let args = Args::parse_from(["whopper", "--fts-match-only"]);
+        assert!(build_inprocess_opts(&args, 3957).is_err());
+    }
 }

--- a/testing/concurrent-simulator/operations.rs
+++ b/testing/concurrent-simulator/operations.rs
@@ -51,27 +51,44 @@ impl TxMode {
 #[derive(Debug, Clone)]
 pub enum Operation {
     /// Begin a transaction
-    Begin { mode: TxMode },
+    Begin {
+        mode: TxMode,
+    },
     /// Commit current transaction
     Commit,
     /// Rollback current transaction
     Rollback,
     /// Create a savepoint within the current transaction
-    Savepoint { name: String },
+    Savepoint {
+        name: String,
+    },
     /// Roll back to a savepoint without leaving the outer transaction
-    RollbackToSavepoint { name: String },
+    RollbackToSavepoint {
+        name: String,
+    },
     /// Release a savepoint without leaving the outer transaction
-    ReleaseSavepoint { name: String },
+    ReleaseSavepoint {
+        name: String,
+    },
     /// Run PRAGMA integrity_check
     IntegrityCheck,
     /// Execute a statement that does not need workload-specific state tracking.
-    Execute { sql: String },
+    Execute {
+        sql: String,
+    },
     /// Run WAL checkpoint with specified mode
-    WalCheckpoint { mode: String },
+    WalCheckpoint {
+        mode: String,
+    },
     /// Create a simple key-value table
-    CreateSimpleTable { table_name: String },
+    CreateSimpleTable {
+        table_name: String,
+    },
     /// Select from a simple table by key
-    SimpleSelect { table_name: String, key: String },
+    SimpleSelect {
+        table_name: String,
+        key: String,
+    },
     /// Insert into a simple table
     SimpleInsert {
         table_name: String,
@@ -79,13 +96,21 @@ pub enum Operation {
         value_length: usize,
     },
     /// Generic SELECT query
-    Select { sql: String },
+    Select {
+        sql: String,
+    },
     /// Generic INSERT query
-    Insert { sql: String },
+    Insert {
+        sql: String,
+    },
     /// Generic UPDATE query
-    Update { sql: String },
+    Update {
+        sql: String,
+    },
     /// Generic DELETE query
-    Delete { sql: String },
+    Delete {
+        sql: String,
+    },
     /// Create an index
     CreateIndex {
         sql: String,
@@ -93,9 +118,14 @@ pub enum Operation {
         table_name: String,
     },
     /// Drop an index
-    DropIndex { sql: String, index_name: String },
+    DropIndex {
+        sql: String,
+        index_name: String,
+    },
     /// Create Elle list table for consistency checking
-    CreateElleTable { table_name: String },
+    CreateElleTable {
+        table_name: String,
+    },
     /// Append value to an Elle list key
     ElleAppend {
         table_name: String,
@@ -103,7 +133,10 @@ pub enum Operation {
         value: i64,
     },
     /// Read an Elle list by key
-    ElleRead { table_name: String, key: String },
+    ElleRead {
+        table_name: String,
+        key: String,
+    },
     /// Write a single value to an Elle rw-register key
     ElleRwWrite {
         table_name: String,
@@ -111,7 +144,10 @@ pub enum Operation {
         value: i64,
     },
     /// Read a single value from an Elle rw-register key
-    ElleRwRead { table_name: String, key: String },
+    ElleRwRead {
+        table_name: String,
+        key: String,
+    },
     /// Create a sequence with specified parameters
     CreateSequence {
         seq_name: String,
@@ -122,7 +158,9 @@ pub enum Operation {
         cycle: bool,
     },
     /// Call nextval('seq_name') — returns an integer
-    NextVal { seq_name: String },
+    NextVal {
+        seq_name: String,
+    },
     /// Call setval('seq_name', value, is_called)
     SetVal {
         seq_name: String,
@@ -130,37 +168,59 @@ pub enum Operation {
         is_called: bool,
     },
     /// Call currval('seq_name') — returns the last value from nextval in this session
-    CurrVal { seq_name: String },
+    CurrVal {
+        seq_name: String,
+    },
     /// Drop a sequence
-    DropSequence { seq_name: String },
+    DropSequence {
+        seq_name: String,
+    },
     /// Create a table with a column that defaults to nextval() of an existing sequence
     CreateTableWithSeqDefault {
         table_name: String,
         seq_name: String,
     },
     /// Insert a row into a table that has a sequence-backed DEFAULT column
-    InsertSeqDefault { table_name: String },
+    InsertSeqDefault {
+        table_name: String,
+    },
     /// Insert a row into the AUTOINCREMENT table with NULL rowid.
     /// RETURNING id gives the engine-assigned rowid back so the
     /// `AutoincWatermarkMonotonicity` property can verify it strictly
     /// advanced past the previous committed max.
-    AutoincInsert { payload: String },
+    AutoincInsert {
+        payload: String,
+    },
     /// Reassign an existing rowid in the AUTOINCREMENT table to a higher
     /// value. The historical bug class: this should bump
     /// `sqlite_sequence.seq` so subsequent NULL-rowid inserts skip the
     /// reassigned region instead of colliding with it.
-    AutoincUpdateRowid { old_id: i64, new_id: i64 },
+    AutoincUpdateRowid {
+        old_id: i64,
+        new_id: i64,
+    },
     /// Delete a row from the AUTOINCREMENT table.  Mostly there to give
     /// the table some non-trivial churn so the watermark/btree interplay
     /// has fewer trivially-flat scenarios.
-    AutoincDelete { id: i64 },
+    AutoincDelete {
+        id: i64,
+    },
     /// Self-differential FTS check: within one statement (one snapshot),
     /// compare the ids `fts_match` returns against a base-table token scan.
     /// Returns one row `(symmetric difference size, index present)`; the
     /// `FtsSelfDifferentialProperty` requires `(0, 1)`. The second column
     /// matters because `fts_match` has a scalar fallback: without the index
     /// both sides are table scans and the difference is trivially 0.
-    FtsMatchDifferential { token: String },
+    FtsMatchDifferential {
+        token: String,
+        check_ranking: bool,
+    },
+    FtsOptimize,
+    FtsCheckRows {
+        first_id: i64,
+        bodies: [Option<String>; 2],
+        scenario_complete: bool,
+    },
 }
 pub type OpResult = Result<Vec<Vec<Value>>, LimboError>;
 /// Context passed to Operation::start_op and Operation::finish_op.
@@ -306,32 +366,57 @@ impl Operation {
                     table = crate::AUTOINC_TABLE_NAME
                 )
             }
-            Operation::FtsMatchDifferential { token } => {
+            Operation::FtsOptimize => format!("OPTIMIZE INDEX {}", crate::workloads::FTS_SIM_INDEX),
+            Operation::FtsCheckRows { first_id, .. } => format!(
+                "SELECT id, body FROM {} WHERE id BETWEEN {first_id} AND {} ORDER BY id",
+                crate::workloads::FTS_SIM_TABLE,
+                first_id + 1
+            ),
+            Operation::FtsMatchDifferential {
+                token,
+                check_ranking,
+            } => {
                 // Bodies are space-joined single tokens, so the padded LIKE
                 // is an exact token match — an FTS-free oracle in the same
                 // snapshot as the fts_match probe.
                 let table = crate::workloads::FTS_SIM_TABLE;
                 let index = crate::workloads::FTS_SIM_INDEX;
+                let query = format!("\"{token}\"");
+                let (fts_order, scan_order) = if *check_ranking {
+                    (
+                        format!("fts_score(body, '{query}') DESC, id LIMIT 5"),
+                        "length(body)-length(replace(body, ' ', '')), id LIMIT 5",
+                    )
+                } else {
+                    ("id".to_string(), "id")
+                };
                 format!(
                     "SELECT \
                        (SELECT count(*) FROM (\
-                          SELECT id FROM {table} WHERE fts_match(body, '{token}') \
+                          SELECT id FROM {table} WHERE fts_match(body, '{query}') \
                           EXCEPT \
                           SELECT id FROM {table} WHERE (' '||body||' ') LIKE '% {token} %')) \
                      + (SELECT count(*) FROM (\
                           SELECT id FROM {table} WHERE (' '||body||' ') LIKE '% {token} %' \
                           EXCEPT \
-                          SELECT id FROM {table} WHERE fts_match(body, '{token}'))), \
+                          SELECT id FROM {table} WHERE fts_match(body, '{query}'))), \
                        (SELECT count(*) FROM sqlite_schema \
                           WHERE type = 'index' AND name = '{index}'), \
                        (SELECT group_concat(id) FROM (\
-                          SELECT id FROM {table} WHERE fts_match(body, '{token}') \
+                          SELECT id FROM {table} WHERE fts_match(body, '{query}') \
                           EXCEPT \
                           SELECT id FROM {table} WHERE (' '||body||' ') LIKE '% {token} %')), \
                        (SELECT group_concat(id) FROM (\
                           SELECT id FROM {table} WHERE (' '||body||' ') LIKE '% {token} %' \
                           EXCEPT \
-                          SELECT id FROM {table} WHERE fts_match(body, '{token}')))"
+                          SELECT id FROM {table} WHERE fts_match(body, '{query}'))), \
+                       (SELECT group_concat(id) FROM (\
+                          SELECT id \
+                          FROM {table} WHERE fts_match(body, '{query}') \
+                          ORDER BY {fts_order})), \
+                       (SELECT group_concat(id) FROM (\
+                          SELECT id FROM {table} WHERE (' '||body||' ') LIKE '% {token} %' \
+                          ORDER BY {scan_order}))"
                 )
             }
         }
@@ -466,9 +551,21 @@ impl Operation {
             Operation::AutoincDelete { .. } => {
                 stats.deletes += 1;
             }
-            Operation::FtsMatchDifferential { .. } => {
+            Operation::FtsMatchDifferential { token, .. } => {
                 stats.fts_checks += 1;
+                stats.fts_phrase_checks += usize::from(token.contains(' '));
             }
+            Operation::FtsOptimize => stats.fts_optimizes += 1,
+            Operation::FtsCheckRows {
+                scenario_complete, ..
+            } => {
+                stats.fts_row_checks += 1;
+                stats.fts_rollback_scenarios += usize::from(*scenario_complete);
+            }
+            Operation::RollbackToSavepoint { .. } => stats.savepoint_rollbacks += 1,
+            Operation::ReleaseSavepoint { .. } => stats.savepoint_releases += 1,
+            Operation::Commit => stats.commits += 1,
+            Operation::Rollback => stats.rollbacks += 1,
             _ => {}
         }
     }

--- a/testing/concurrent-simulator/properties.rs
+++ b/testing/concurrent-simulator/properties.rs
@@ -323,7 +323,11 @@ impl Property for FtsSelfDifferentialProperty {
         op: &Operation,
         result: &OpResult,
     ) -> anyhow::Result<()> {
-        let Operation::FtsMatchDifferential { token } = op else {
+        let Operation::FtsMatchDifferential {
+            token,
+            check_ranking,
+        } = op
+        else {
             return Ok(());
         };
         let rows = match result {
@@ -357,6 +361,12 @@ impl Property for FtsSelfDifferentialProperty {
                  (fts-only ids: {:?}, scan-only ids: {:?})",
                 row.get(2),
                 row.get(3)
+            );
+        }
+        if row.len() != 6 || row[4] != row[5] {
+            bail!(
+                "step {step} fiber {fiber_id}: FTS ordered IDs disagree with the \
+                 base-table oracle for {token:?} (check_ranking={check_ranking}): {row:?}"
             );
         }
         Ok(())
@@ -2133,6 +2143,43 @@ impl Property for SequenceCorrectnessProperty {
 #[allow(clippy::items_after_test_module)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn fts_oracle_rejects_wrong_sets_order_missing_index_and_short_rows() {
+        let valid = vec![
+            Value::from_i64(0),
+            Value::from_i64(1),
+            Value::Null,
+            Value::Null,
+            Value::build_text("9,2"),
+            Value::build_text("9,2"),
+        ];
+        for check_ranking in [false, true] {
+            let op = Operation::FtsMatchDifferential {
+                token: "alpha bravo".into(),
+                check_ranking,
+            };
+            let check =
+                |rows| FtsSelfDifferentialProperty.finish_op(7, 2, None, 0, 0, &op, &Ok(rows));
+            assert!(check(vec![valid.clone()]).is_ok());
+            for (column, value) in [
+                (0, Value::from_i64(1)),
+                (1, Value::from_i64(0)),
+                (4, Value::build_text("2,9")),
+                (4, Value::Null),
+            ] {
+                let mut row = valid.clone();
+                row[column] = value;
+                assert!(check(vec![row]).is_err());
+            }
+            assert!(check(vec![valid[..4].to_vec()]).is_err());
+            assert!(check(vec![]).is_err());
+            let mut empty = valid.clone();
+            empty[4] = Value::Null;
+            empty[5] = Value::Null;
+            assert!(check(vec![empty]).is_ok());
+        }
+    }
 
     fn test_output_path(label: &str) -> PathBuf {
         std::env::temp_dir().join(format!(

--- a/testing/concurrent-simulator/regression_tests_cross_platform.rs
+++ b/testing/concurrent-simulator/regression_tests_cross_platform.rs
@@ -262,7 +262,13 @@ fn test_fts_workloads_use_the_index_and_replay_with_the_seed() {
             (20, Box::new(FtsInsertWorkload)),
             (8, Box::new(FtsUpdateWorkload)),
             (6, Box::new(FtsDeleteWorkload)),
-            (12, Box::new(FtsMatchWorkload)),
+            (
+                12,
+                Box::new(FtsMatchWorkload {
+                    check_ranking: false,
+                    phrases: false,
+                }),
+            ),
             (2, Box::new(FtsOptimizeWorkload)),
             (10, Box::new(BeginWorkload)),
             (8, Box::new(CommitWorkload)),
@@ -333,6 +339,7 @@ fn test_fts_workloads_use_the_index_and_replay_with_the_seed() {
     }
     let differential = Operation::FtsMatchDifferential {
         token: "alpha".to_string(),
+        check_ranking: false,
     }
     .sql();
     let mut stmt = conn

--- a/testing/concurrent-simulator/workloads.rs
+++ b/testing/concurrent-simulator/workloads.rs
@@ -844,6 +844,25 @@ impl Workload for AutoincDeleteWorkload {
 pub const FTS_SIM_TABLE: &str = "fts_docs";
 pub const FTS_SIM_INDEX: &str = "fts_docs_fts";
 
+pub fn fts_sim_workloads(check_ranking: bool) -> Vec<(u32, Box<dyn Workload>)> {
+    vec![
+        (20, Box::new(FtsInsertWorkload)),
+        (8, Box::new(FtsUpdateWorkload)),
+        (6, Box::new(FtsDeleteWorkload)),
+        (
+            12,
+            Box::new(FtsMatchWorkload {
+                check_ranking,
+                phrases: true,
+            }),
+        ),
+        (2, Box::new(FtsOptimizeWorkload)),
+        (10, Box::new(BeginWorkload)),
+        (8, Box::new(CommitWorkload)),
+        (3, Box::new(RollbackWorkload)),
+    ]
+}
+
 /// Bootstrap statements for the FTS table and its index.
 pub fn fts_sim_schema() -> Vec<(String, String)> {
     vec![
@@ -864,7 +883,7 @@ pub fn fts_sim_schema() -> Vec<(String, String)> {
 
 /// Small fixed vocabulary so the self-differential's padded-LIKE oracle is
 /// exact token matching, and so matches stay non-trivial.
-const FTS_SIM_TOKENS: &[&str] = &[
+pub(crate) const FTS_SIM_TOKENS: &[&str] = &[
     "alpha", "bravo", "charlie", "delta", "echo", "foxtrot", "golf", "hotel",
 ];
 
@@ -929,20 +948,28 @@ pub struct FtsOptimizeWorkload;
 
 impl Workload for FtsOptimizeWorkload {
     fn generate(&self, _ctx: &WorkloadContext, _rng: &mut ChaCha8Rng) -> Option<Operation> {
-        Some(Operation::Execute {
-            sql: format!("OPTIMIZE INDEX {FTS_SIM_INDEX}"),
-        })
+        Some(Operation::FtsOptimize)
     }
 }
 
 /// Run the FTS self-differential (see [`Operation::FtsMatchDifferential`]).
-pub struct FtsMatchWorkload;
+pub struct FtsMatchWorkload {
+    pub check_ranking: bool,
+    pub phrases: bool,
+}
 
 impl Workload for FtsMatchWorkload {
     fn generate(&self, _ctx: &WorkloadContext, rng: &mut ChaCha8Rng) -> Option<Operation> {
         let token = FTS_SIM_TOKENS.choose(rng).expect("vocabulary is not empty");
+        let token = if self.phrases && rng.random_bool(0.3) {
+            let next = FTS_SIM_TOKENS.choose(rng).expect("vocabulary is not empty");
+            format!("{token} {next}")
+        } else {
+            token.to_string()
+        };
         Some(Operation::FtsMatchDifferential {
-            token: token.to_string(),
+            token,
+            check_ranking: self.check_ranking,
         })
     }
 }


### PR DESCRIPTION
## Description

Port the focused FTS/MVCC simulator from #8855 onto main without importing the other FTS engine, planner, or temporary-file changes from that stack. Add a second, rollback-heavy scenario for testing the current implementation and later FTS changes.

- `--mode fts-mvcc`: competing insert/replace, update, delete, MATCH, OPTIMIZE and transaction operations; same-statement matching and top-five ranking oracles.
- `--mode fts-mvcc-rollback`: one writer plus snapshot readers. Nested savepoints, 75% rollback decisions, outer rollback discarding an inner savepoint, reuse of the same outer savepoint after another write/OPTIMIZE, release, commit and full rollback.
- Check FTS results and exact expected table rows before and after every OPTIMIZE and across rollback boundaries. Readers require unchanged results within their transaction. Expected-row checks catch rollback mistakes even if the table and FTS index are wrong together.
- Report successful OPTIMIZE statements, expected-row checks, completed writer scenarios and transaction/savepoint operations. A rollback run that completes no writer scenario returns an error.
- Keep ranking enabled by default; `--fts-match-only` allows storage/snapshot testing independently of the current ranking failure.

**Not enabled in CI:** no workflow changes and no new simulation mode selected by CI. The focused database scenarios live in the separate `fts_mvcc_scenarios` target and all require explicit `--ignored`. Existing fast-mode probes remain single-token. Ordinary harness unit tests still run normally.

## Motivation and context

This provides a main-based baseline that can be reused when changing FTS. Separating the rollback writer from readers is intentional: the competing-writer version repeatedly aborted before completing savepoint/OPTIMIZE sequences. The original `fts-mvcc` mode retains competing-writer coverage.

The independent rank oracle assumes 1–4 distinct words per document, no boosts, and the existing tokenizer. It checks ordering, not exact BM25 scores. No production engine or dependency changes are included.

## Validation and known limitations

- `cargo test -p turso_whopper --no-fail-fast`: 61 ordinary tests pass; the five manual database scenarios are ignored as requested.
- `cargo fmt --check` and `cargo clippy -p turso_whopper --all-targets -- --deny=warnings` pass.
- Manual tests cover three six-connection seeds and byte-for-byte replay; snapshot/OPTIMIZE/savepoint/full-rollback/reopen behavior; all eight inner/outer/full-rollback outcome combinations; and a six-connection rollback scenario with asserted completion and successful optimizes.
- The manual ranking regression still fails against the unchanged main implementation: `alpha bravo` returns `1,2` instead of `2,1`. Its correct expectation is preserved. Running the full manual suite therefore returns a failure.
- The 18,000-step rollback CLI run below passes: 212 phrase checks, 9 successful OPTIMIZE statements, 22 expected-row checks and 2 completed writer scenarios. With allocation-failure probability 0.05 and reopen probability 0.0001, the same budget injected 14 failures but completed no full writer scenario; that run correctly returned an error, not a pass.
- Longer runs can exhaust descriptors because current SimulatorIO retains temporary sorter files. This PR does not include the separate ownership fix. Frequent reopen can also interrupt every long writer sequence; the completion assertion reports that rather than claiming successful coverage.
- This is clean-reopen testing, not process-crash recovery or multiprocess MVCC testing.

Run the manual suite:

```sh
cargo test -p turso_whopper --test fts_mvcc_scenarios -- --ignored --nocapture --test-threads=1
```

Run the rollback scenario without the known ranking failure:

```sh
SEED=3957 cargo run -p turso_whopper -- \
  --mode fts-mvcc-rollback --fts-match-only --max-connections 6 --max-steps 18000 \
  --allocation-fault-probability 0 --reopen-probability 0
```

## Description of AI Usage

Implemented with Amp at pedrocarlo's request. Amp extracted the test-only work, implemented the rollback scenario and assertions, ran local tests and fault-injection experiments, and documented the existing main failures. Related conversation: https://ampcode.com/threads/T-01a0833e-2fc3-778f-97da-3dc54904ccd4
