### PR TITLE
core: enforce query_only for pragma writes and trigger drops

### DIFF
--- a/core/translate/mod.rs
+++ b/core/translate/mod.rs
@@ -176,6 +176,7 @@ pub fn translate_inner(
             | ast::Stmt::Delete { .. }
             | ast::Stmt::DropIndex { .. }
             | ast::Stmt::DropTable { .. }
+            | ast::Stmt::DropTrigger { .. }
             | ast::Stmt::DropType { .. }
             | ast::Stmt::DropDomain { .. }
             | ast::Stmt::DropView { .. }

--- a/core/translate/pragma.rs
+++ b/core/translate/pragma.rs
@@ -234,6 +234,7 @@ pub fn translate_pragma(
 
     let database_id = resolver.resolve_database_id(name)?;
     let schema_was_explicit = name.db_name.is_some();
+    let query_only = connection.get_query_only();
 
     let mode = match body {
         None => query_pragma(
@@ -279,6 +280,9 @@ pub fn translate_pragma(
             )?,
         },
     };
+    if query_only && matches!(mode, TransactionMode::Write) {
+        bail_parse_error!("Cannot execute write statement in query_only mode");
+    }
     match mode {
         TransactionMode::None => {}
         TransactionMode::Read => {

--- a/sqlite/conformance/sqlite-sqltests/pragma_query_only.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/pragma_query_only.sqltest
@@ -20,3 +20,27 @@ test pragma-query-only-float-disable {
 expect {
     0
 }
+
+test pragma-query-only-blocks-user-version {
+    PRAGMA query_only = 1;
+    PRAGMA user_version = 123;
+}
+expect error {
+}
+
+test pragma-query-only-blocks-application-id {
+    PRAGMA query_only = 1;
+    PRAGMA application_id = 123;
+}
+expect error {
+}
+
+test pragma-query-only-blocks-drop-trigger {
+    CREATE TABLE items(id INTEGER PRIMARY KEY);
+    CREATE TABLE audit(id INTEGER);
+    CREATE TRIGGER changed AFTER INSERT ON items BEGIN INSERT INTO audit VALUES (new.id); END;
+    PRAGMA query_only = 1;
+    DROP TRIGGER changed;
+}
+expect error {
+}


### PR DESCRIPTION
## Description

Enforce `PRAGMA query_only` for all write-mode pragmas and `DROP TRIGGER`.
Regression coverage verifies that header writes and trigger removal are refused
while query-only mode is enabled.

## Motivation and context

`PRAGMA user_version`, `PRAGMA application_id`, and `DROP TRIGGER` previously
changed persistent state even though the connection reported
`PRAGMA query_only = 1`. Other write statements already rejected this mode.

Fixes #8862.

## Description of AI Usage

AI was used to inspect the reported behavior and current translation paths,
implement the focused query-only guard and regression tests, and run the
validation commands. The patch was reviewed against the existing transaction
mode and SQL conformance test patterns.

## Testing

- `cargo +stable fmt --all -- --check`
- `cargo check -p turso_core`
- `cargo test -p sqltest --lib`
- SQL conformance `pragma_query_only.sqltest` with the Rust backend: 5 passed
