### PR TITLE
core: only validate ADD COLUMN defaults for STRICT tables

### DIFF
--- a/core/translate/alter.rs
+++ b/core/translate/alter.rs
@@ -1327,7 +1327,11 @@ pub fn translate_alter_table(
                     }
                 }
 
-                default_type_mismatch = strict_default_type_mismatch(&column)?;
+                default_type_mismatch = if btree.is_strict {
+                    strict_default_type_mismatch(&column)?
+                } else {
+                    false
+                };
             }
 
             // If a column has no explicit DEFAULT but its custom type defines

--- a/sqlite/conformance/sqlite-sqltests/alter_table.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/alter_table.sqltest
@@ -273,6 +273,18 @@ expect {
 }
 
 @cross-check-integrity
+test alter-table-add-column-nonstrict-default-types {
+    CREATE TABLE t (a INTEGER);
+    INSERT INTO t VALUES (1);
+    ALTER TABLE t ADD COLUMN b BLOB DEFAULT '';
+    ALTER TABLE t ADD COLUMN c INTEGER DEFAULT 3.7;
+    SELECT quote(b), typeof(b), quote(c), typeof(c) FROM t;
+}
+expect {
+    ''|text|3.7|real
+}
+
+@cross-check-integrity
 test alter-table-add-column-nullability {
     CREATE TABLE t (a INTEGER);
     ALTER TABLE t ADD COLUMN b BLOB NULL;


### PR DESCRIPTION
Fix #8763: apply the ADD COLUMN default type check only to STRICT tables.

The strict default compatibility check was running for ordinary tables whenever existing rows made the default materialization path execute. That rejected valid affinity defaults such as `BLOB DEFAULT ''` and `INTEGER DEFAULT 3.7`, while empty tables bypassed the check.

This change gates the check on the table's `STRICT` flag, preserving the validation for STRICT tables and allowing ordinary SQLite affinity behavior for non-STRICT tables. It adds SQLLogicTest coverage for both non-STRICT defaults and keeps the existing STRICT coverage.

Validation:

- `cargo +stable fmt --all -- --check`
- `cargo check -p turso_core`
- `cargo test -p sqltest --lib`
- Focused `alter_table.sqltest` rust backend: 217 passed
