### PR TITLE
json: preserve SQL NULL in jsonb()

### DIFF
--- a/core/json/mod.rs
+++ b/core/json/mod.rs
@@ -71,6 +71,9 @@ pub fn get_json(json_value: &Value, indent: Option<&str>) -> crate::Result<Value
 /// Converts a value to `Jsonb`, using the provided cache, and returns a `Value::Blob` containing
 /// the jsonb.
 pub fn jsonb(json_value: &Value, cache: &JsonCacheCell) -> crate::Result<Value> {
+    if matches!(json_value, Value::Null) {
+        return Ok(Value::Null);
+    }
     let json_conv_fn = curry_convert_dbtype_to_jsonb(Conv::Strict);
 
     let jsonbin =

--- a/sqlite/conformance/sqlite-sqltests/json/default.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/json/default.sqltest
@@ -1915,6 +1915,13 @@ expect {
     {"name":"John","age":30,"city":"New York"}
 }
 
+test jsonb_null_is_sql_null {
+    SELECT typeof(jsonb(NULL)), jsonb(NULL) IS NULL;
+}
+expect {
+    null|1
+}
+
 test json_complex_nested {
     SELECT json(jsonb('{"complex": {"nested": ["array", "of", "values"], "numbers": [1, 2, 3]}}'));
 }


### PR DESCRIPTION
Fix #8743: preserve SQL NULL when converting a top-level value with `jsonb()`.

`jsonb(NULL)` was returning a one-byte JSONB null blob (`X'00'`). SQLite's scalar `jsonb()` propagates SQL NULL, while JSON null remains available when it is written inside a JSON array or object. Returning a SQL NULL here also prevents nullable JSON columns from changing type and value during conversion.

Validation:

- `cargo +stable fmt --all -- --check`
- `cargo check -p turso_core`
- Focused SQLLogicTest `jsonb_null_is_sql_null` with the Rust backend: 2 passed
