### PR TITLE
json: skip NULL labels in object aggregates

### DIFF
--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -7541,6 +7541,11 @@ fn update_agg_payload(
                     "JsonGroupObject/JsonbGroupObject: no value provided".to_string(),
                 ));
             };
+            // SQLite skips rows whose object label is SQL NULL. A NULL value is
+            // still encoded as JSON null, so only the key is filtered here.
+            if matches!(arg, Value::Null) {
+                return Ok(());
+            }
             ensure_blob_arg_is_jsonb(value.as_value_ref())?;
             let mut key_vec = convert_dbtype_to_raw_jsonb(arg, Conv::ToString)?;
             let mut val_vec = convert_dbtype_to_raw_jsonb(value, Conv::NotStrict)?;
@@ -7754,12 +7759,20 @@ fn finalize_agg_payload(func: &AggFunc, payload: &[Value]) -> Result<Value> {
         #[cfg(feature = "json")]
         AggFunc::JsonGroupObject => {
             let data = payload[0].to_blob().expect("Should be blob");
-            json_from_raw_bytes_agg(data, false)?
+            if data.is_empty() {
+                Value::Text(Text::json("{}".to_string()))
+            } else {
+                json_from_raw_bytes_agg(data, false)?
+            }
         }
         #[cfg(feature = "json")]
         AggFunc::JsonbGroupObject => {
             let data = payload[0].to_blob().expect("Should be blob");
-            json_from_raw_bytes_agg(data, true)?
+            if data.is_empty() {
+                Value::Blob(json::jsonb::Jsonb::make_empty_obj(1)?.data())
+            } else {
+                json_from_raw_bytes_agg(data, true)?
+            }
         }
         #[cfg(feature = "json")]
         AggFunc::JsonGroupArray => {

--- a/sqlite/conformance/sqlite-sqltests/agg-functions/json-group-object-null-label.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/agg-functions/json-group-object-null-label.sqltest
@@ -1,0 +1,27 @@
+@database :memory:
+
+test json_group_object_skips_null_label {
+    CREATE TABLE t(k TEXT, n INT);
+    INSERT INTO t VALUES('a', 1), (NULL, 2), ('b', 3);
+    SELECT json_group_object(k, n) FROM t;
+}
+expect {
+    {"a":1,"b":3}
+}
+
+test jsonb_group_object_skips_null_label {
+    CREATE TABLE t(k TEXT, n INT);
+    INSERT INTO t VALUES('a', 1), (NULL, 2), ('b', 3);
+    SELECT json(jsonb_group_object(k, n)) FROM t;
+}
+expect {
+    {"a":1,"b":3}
+}
+
+test json_group_object_null_label_only {
+    SELECT json_group_object(NULL, 1), json(jsonb_group_object(NULL, 1)),
+           json_group_object('a', NULL), json_group_array(NULL);
+}
+expect {
+    {}|{}|{"a":null}|[null]
+}


### PR DESCRIPTION
Fix #8758: skip rows with SQL NULL labels in JSON object aggregates.

SQLite ignores an input row when the label passed to `json_group_object` or `jsonb_group_object` is SQL NULL, while retaining SQL NULL values as JSON null. Turso previously appended a null JSONB element as an object key, producing malformed JSONB and aborting the text aggregate. This change filters only the label and returns the correct empty object when every row is skipped.

Validation:

- `cargo +stable fmt --all -- --check`
- `cargo check -p turso_core`
- Focused SQLLogicTest `json-group-object-null-label.sqltest` with the Rust backend: 3 passed
