### PR TITLE
pragma: accept case-insensitive names

### DIFF
--- a/core/translate/pragma.rs
+++ b/core/translate/pragma.rs
@@ -227,9 +227,20 @@ pub fn translate_pragma(
         return Ok(());
     }
 
-    let Ok(pragma) = PragmaName::from_str(name.name.as_str()) else {
-        // SQLite silently ignores unknown PRAGMA names.
-        return Ok(());
+    let pragma = match PragmaName::from_str(name.name.as_str()) {
+        Ok(pragma) => pragma,
+        Err(_) => {
+            // PRAGMA names are case-insensitive in SQLite. Keep the exact
+            // parser spelling fast, then resolve other spellings against the
+            // canonical enum names before treating a name as unknown.
+            let Some(pragma) = PragmaName::iter()
+                .find(|pragma| pragma.to_string().eq_ignore_ascii_case(name.name.as_str()))
+            else {
+                // SQLite silently ignores unknown PRAGMA names.
+                return Ok(());
+            };
+            pragma
+        }
     };
 
     let database_id = resolver.resolve_database_id(name)?;

--- a/sqlite/conformance/sqlite-sqltests/pragma/case-insensitive-names.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/pragma/case-insensitive-names.sqltest
@@ -1,0 +1,25 @@
+@database :memory:
+
+test pragma_case_insensitive_setter {
+    PRAGMA USER_VERSION = 9;
+    PRAGMA user_version;
+}
+expect {
+    9
+}
+
+test pragma_case_insensitive_table_info {
+    CREATE TABLE t(id INTEGER PRIMARY KEY);
+    PRAGMA TABLE_INFO(t);
+}
+expect {
+    0|id|INTEGER|0||1
+}
+
+test pragma_case_insensitive_foreign_keys {
+    PRAGMA FOREIGN_KEYS = ON;
+    PRAGMA FOREIGN_KEYS;
+}
+expect {
+    1
+}


### PR DESCRIPTION
Fix #8736: resolve PRAGMA names case-insensitively.

SQLite accepts any casing for PRAGMA names. Turso previously parsed only the canonical lower-case spelling, silently ignoring upper-case setters and returning empty results for reader PRAGMAs. This change retains the exact lookup fast path and falls back to a case-insensitive match against the canonical `PragmaName` variants before applying the existing query or update behavior.

Validation:

- `cargo +stable fmt --all -- --check`
- `cargo check -p turso_core`
- Focused SQLLogicTest `pragma/case-insensitive-names.sqltest` with the Rust backend: 3 passed
