### PR TITLE
parser: quote numeric identifiers in rewritten SQL

### DIFF
--- a/sqlite/conformance/sqlite-sqltests/check_constraint.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/check_constraint.sqltest
@@ -1620,6 +1620,23 @@ expect {
     1
 }
 
+# References rewritten by RENAME COLUMN must quote names that cannot be bare
+# identifiers, including names beginning with a digit.
+@cross-check-integrity
+test check_constraint_rename_column_to_numeric_name_ddl {
+    CREATE TABLE t(a INTEGER CHECK(a > 0));
+    CREATE INDEX ix ON t(a);
+    CREATE VIEW v AS SELECT a FROM t WHERE a > 2;
+    ALTER TABLE t RENAME COLUMN a TO "2024";
+    SELECT
+        (SELECT sql LIKE '%CHECK%"2024" > 0%' FROM sqlite_master WHERE name = 't'),
+        (SELECT sql LIKE '%"2024"%' FROM sqlite_master WHERE name = 'ix'),
+        (SELECT sql LIKE '%"2024" > 2%' FROM sqlite_master WHERE name = 'v');
+}
+expect {
+    1|1|1
+}
+
 @cross-check-integrity
 test check_constraint_rename_column_to_keyword_still_works {
     CREATE TABLE t("value" INTEGER CHECK("value" > 0));

--- a/sqlite/parser/src/ast.rs
+++ b/sqlite/parser/src/ast.rs
@@ -1297,7 +1297,12 @@ impl Name {
         }
         let value = self.value.as_bytes();
         let safe_char = |&c: &u8| c.is_ascii_alphanumeric() || c == b'_';
-        if !value.is_empty() && value.iter().all(safe_char) && !is_quotable_keyword(value) {
+        let starts_with_digit = value.first().is_some_and(u8::is_ascii_digit);
+        if !value.is_empty()
+            && !starts_with_digit
+            && value.iter().all(safe_char)
+            && !is_quotable_keyword(value)
+        {
             self.value.clone()
         } else {
             format!("\"{}\"", self.value.replace("\"", "\"\""))


### PR DESCRIPTION
Fix #8748: keep numeric column names quoted when rewriting dependent schema SQL.

`RENAME COLUMN ... TO "2024"` rewrote CHECK constraints, expression indexes, and views with `Name::exact("2024")`. The SQL renderer treated a leading digit as a safe bare identifier, so persisted schema text was reparsed as the integer literal `2024` after reopening. Identifier rendering now requires the first character to be nonnumeric, preserving quotes for numeric names while retaining existing keyword and special-character quoting.

Validation:

- `cargo +stable fmt --all -- --check`
- `cargo test -p turso_parser`: 28 passed
- Focused SQLLogicTest `check_constraint_rename_column_to_numeric_name_ddl` with the Rust backend: 1 passed
