### PR TITLE
Preserve ALTER TABLE schema constraints

### DIFF
--- a/core/schema.rs
+++ b/core/schema.rs
@@ -1995,6 +1995,7 @@ impl Schema {
                 root_page: main_root,
                 columns: cols,
                 primary_key_columns: vec![],
+                primary_key_is_inline: false,
                 has_rowid: true,
                 is_strict: false,
                 has_autoincrement: false,
@@ -2728,6 +2729,7 @@ impl TryClone for BTreeTable {
             root_page: self.root_page,
             name: self.name.clone(),
             primary_key_columns: self.primary_key_columns.try_clone()?,
+            primary_key_is_inline: self.primary_key_is_inline,
             columns: self.columns.try_clone()?,
             has_rowid: self.has_rowid,
             is_strict: self.is_strict,
@@ -3326,6 +3328,12 @@ pub struct BTreeTable {
     pub root_page: i64,
     pub name: String,
     pub primary_key_columns: Vec<(String, SortOrder)>,
+    /// Whether the single-column PRIMARY KEY was declared inline on its column.
+    ///
+    /// A table-level `PRIMARY KEY (x)` and an inline `x PRIMARY KEY` have
+    /// different automatic-index ordering, so ALTER TABLE rewrites must retain
+    /// the declaration form.
+    pub primary_key_is_inline: bool,
     columns: Vec<Column>,
     pub has_rowid: bool,
     pub is_strict: bool,
@@ -3392,6 +3400,7 @@ impl BTreeTable {
             root_page,
             name,
             primary_key_columns,
+            primary_key_is_inline: false,
             columns,
             has_rowid,
             is_strict: characteristics.contains(BTreeCharacteristics::STRICT),
@@ -3642,7 +3651,7 @@ impl BTreeTable {
     /// `CREATE TABLE t (x)`, whereas sqlite stores it with the original extra whitespace.
     pub fn to_sql(&self) -> String {
         let mut sql = format!("CREATE TABLE {} (", quote_ident(&self.name));
-        let needs_pk_inline = self.primary_key_columns.len() == 1;
+        let needs_pk_inline = self.primary_key_is_inline && self.primary_key_columns.len() == 1;
         // Add columns
         for (i, column) in self.columns.iter().enumerate() {
             if i > 0 {
@@ -3668,12 +3677,36 @@ impl BTreeTable {
 
             if column.unique() {
                 sql.push_str(" UNIQUE");
+                let conflict_clause = self
+                    .unique_sets
+                    .iter()
+                    .find(|unique_set| {
+                        !unique_set.is_primary_key
+                            && unique_set.columns.len() == 1
+                            && unique_set.columns[0].name.eq_ignore_ascii_case(column_name)
+                    })
+                    .and_then(|unique_set| unique_set.conflict_clause);
+                Self::append_conflict_clause(&mut sql, conflict_clause);
             }
             if needs_pk_inline && column.primary_key() {
                 sql.push_str(" PRIMARY KEY");
+                if self.primary_key_columns[0].1 == SortOrder::Desc {
+                    sql.push_str(" DESC");
+                }
                 if self.has_autoincrement && column.is_rowid_alias() {
                     sql.push_str(" AUTOINCREMENT");
                 }
+                let conflict_clause = self.rowid_alias_conflict_clause.or_else(|| {
+                    self.unique_sets
+                        .iter()
+                        .find(|unique_set| {
+                            unique_set.is_primary_key
+                                && unique_set.columns.len() == 1
+                                && unique_set.columns[0].name.eq_ignore_ascii_case(column_name)
+                        })
+                        .and_then(|unique_set| unique_set.conflict_clause)
+                });
+                Self::append_conflict_clause(&mut sql, conflict_clause);
             }
 
             if let Some(default) = &column.default {
@@ -3717,37 +3750,26 @@ impl BTreeTable {
             }
         }
 
-        let has_table_pk = !self.primary_key_columns.is_empty();
-        // Add table-level PRIMARY KEY constraint if exists
-        if !needs_pk_inline && has_table_pk {
-            sql.push_str(", PRIMARY KEY (");
-            for (i, col) in self.primary_key_columns.iter().enumerate() {
-                if i > 0 {
-                    sql.push_str(", ");
-                }
-                sql.push_str(&col.0);
-            }
-            sql.push(')');
-        }
-
         for fk in &self.foreign_keys {
             sql.push_str(", FOREIGN KEY (");
             for (i, col) in fk.child_columns.iter().enumerate() {
                 if i > 0 {
                     sql.push_str(", ");
                 }
-                sql.push_str(col);
+                sql.push_str(&quote_ident(col));
             }
             sql.push_str(") REFERENCES ");
-            sql.push_str(&fk.parent_table);
-            sql.push('(');
-            for (i, col) in fk.parent_columns.iter().enumerate() {
-                if i > 0 {
-                    sql.push_str(", ");
+            sql.push_str(&quote_ident(&fk.parent_table));
+            if !fk.parent_columns.is_empty() {
+                sql.push('(');
+                for (i, col) in fk.parent_columns.iter().enumerate() {
+                    if i > 0 {
+                        sql.push_str(", ");
+                    }
+                    sql.push_str(&quote_ident(col));
                 }
-                sql.push_str(col);
+                sql.push(')');
             }
-            sql.push(')');
 
             // Add ON DELETE/UPDATE actions, NoAction is default so just make empty in that case
             if fk.on_delete != RefAct::NoAction {
@@ -3789,14 +3811,11 @@ impl BTreeTable {
             sql.push_str(&check_constraint.sql());
         }
 
-        // Add table-level UNIQUE constraints
+        // Add table-level PRIMARY KEY and UNIQUE constraints in their
+        // declaration order.  Column-level unique sets are skipped because
+        // they were emitted with their column above.
         for unique_set in &self.unique_sets {
-            // Skip primary key (handled above)
-            if unique_set.is_primary_key {
-                continue;
-            }
-            // Skip single-column unique constraints that were already emitted inline
-            if unique_set.columns.len() == 1 {
+            if !unique_set.is_primary_key && unique_set.columns.len() == 1 {
                 let col_name = &unique_set.columns[0].name;
                 if let Some((_, col)) = self.get_column(col_name) {
                     if col.unique() {
@@ -3804,14 +3823,22 @@ impl BTreeTable {
                     }
                 }
             }
-            sql.push_str(", UNIQUE (");
+            if unique_set.is_primary_key {
+                if needs_pk_inline {
+                    continue;
+                }
+                sql.push_str(", PRIMARY KEY (");
+            } else {
+                sql.push_str(", UNIQUE (");
+            }
             for (i, unique_column) in unique_set.columns.iter().enumerate() {
                 if i > 0 {
                     sql.push_str(", ");
                 }
-                sql.push_str(&quote_ident(&unique_column.name));
+                Self::append_unique_column_sql(&mut sql, unique_column);
             }
             sql.push(')');
+            Self::append_conflict_clause(&mut sql, unique_set.conflict_clause);
         }
 
         sql.push(')');
@@ -3829,6 +3856,38 @@ impl BTreeTable {
         }
 
         sql
+    }
+
+    fn append_conflict_clause(sql: &mut String, conflict_clause: Option<ResolveType>) {
+        if let Some(conflict_clause) = conflict_clause {
+            sql.push_str(" ON CONFLICT ");
+            sql.push_str(&conflict_clause.to_string());
+        }
+    }
+
+    fn append_unique_column_sql(sql: &mut String, column: &UniqueSetColumn) {
+        sql.push_str(&quote_ident(&column.name));
+        if let Some(collation) = column.collation {
+            match collation {
+                CollationSeq::Binary => sql.push_str(" COLLATE BINARY"),
+                CollationSeq::NoCase => sql.push_str(" COLLATE NOCASE"),
+                CollationSeq::Rtrim => sql.push_str(" COLLATE RTRIM"),
+                CollationSeq::Locale(_) => {
+                    sql.push_str(" COLLATE ");
+                    sql.push_str(&quote_ident(&collation.name()));
+                }
+                CollationSeq::Unset | CollationSeq::Custom(_) => {}
+            }
+        }
+        if column.sort_order == SortOrder::Desc {
+            sql.push_str(" DESC");
+        }
+        if let Some(nulls_order) = column.nulls_order {
+            sql.push_str(match nulls_order {
+                NullsOrder::First => " NULLS FIRST",
+                NullsOrder::Last => " NULLS LAST",
+            });
+        }
     }
 
     fn is_without_rowid_inline_pk(&self, column: &Column) -> bool {
@@ -4478,6 +4537,7 @@ pub fn create_table(tbl_name: &str, body: &CreateTableBody, root_page: i64) -> R
     let has_rowid;
     let mut has_autoincrement = false;
     let mut primary_key_columns = vec![];
+    let mut primary_key_is_inline = false;
     let mut foreign_keys = vec![];
     let mut check_constraints = vec![];
     let mut cols: Vec<Column> = vec![];
@@ -4750,6 +4810,7 @@ pub fn create_table(tbl_name: &str, body: &CreateTableBody, root_page: i64) -> R
                                 );
                             }
                             primary_key = true;
+                            primary_key_is_inline = true;
                             if *auto_increment {
                                 has_autoincrement = true;
                             }
@@ -4999,6 +5060,7 @@ pub fn create_table(tbl_name: &str, body: &CreateTableBody, root_page: i64) -> R
         name: table_name,
         has_rowid,
         primary_key_columns,
+        primary_key_is_inline,
         has_autoincrement,
         columns: cols,
         is_strict,
@@ -5633,6 +5695,7 @@ pub fn sqlite_schema_table() -> Result<BTreeTable> {
         is_strict: false,
         has_autoincrement: false,
         primary_key_columns: try_vec![]?,
+        primary_key_is_inline: false,
         columns,
         foreign_keys: try_vec![]?,
         check_constraints: try_vec![]?,
@@ -6587,6 +6650,7 @@ mod tests {
             is_strict: false,
             has_autoincrement: false,
             primary_key_columns: vec![("nonexistent".to_string(), SortOrder::Asc)],
+            primary_key_is_inline: false,
             columns,
             unique_sets: vec![],
             foreign_keys: vec![],

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -11335,7 +11335,9 @@ pub fn op_function(
 
                                 Some(
                                     ast::Stmt::CreateIndex {
-                                        tbl_name: ast::Name::exact(original_rename_to.to_string()),
+                                        tbl_name: ast::Name::from_bytes(
+                                            original_rename_to.as_str().as_bytes(),
+                                        ),
                                         unique,
                                         if_not_exists,
                                         idx_name,
@@ -11432,7 +11434,9 @@ pub fn op_function(
                                     let new_stmt = ast::Stmt::CreateTable {
                                         tbl_name: ast::QualifiedName {
                                             db_name: None,
-                                            name: ast::Name::exact(original_rename_to.to_string()),
+                                            name: ast::Name::from_bytes(
+                                                original_rename_to.as_str().as_bytes(),
+                                            ),
                                             alias: None,
                                         },
                                         temporary,
@@ -11486,8 +11490,8 @@ pub fn op_function(
                                         ast::Stmt::CreateVirtualTable(ast::CreateVirtualTable {
                                             tbl_name: ast::QualifiedName {
                                                 db_name: tbl_name.db_name,
-                                                name: ast::Name::exact(
-                                                    original_rename_to.to_string(),
+                                                name: ast::Name::from_bytes(
+                                                    original_rename_to.as_str().as_bytes(),
                                                 ),
                                                 alias: None,
                                             },
@@ -11515,7 +11519,9 @@ pub fn op_function(
                                 let new_trigger_tbl_name = if trigger_tbl == rename_from {
                                     ast::QualifiedName {
                                         db_name: trigger_tbl_name.db_name,
-                                        name: ast::Name::exact(original_rename_to.to_string()),
+                                        name: ast::Name::from_bytes(
+                                            original_rename_to.as_str().as_bytes(),
+                                        ),
                                         alias: None,
                                     }
                                 } else {

--- a/sqlite/parser/src/ast.rs
+++ b/sqlite/parser/src/ast.rs
@@ -1297,7 +1297,11 @@ impl Name {
         }
         let value = self.value.as_bytes();
         let safe_char = |&c: &u8| c.is_ascii_alphanumeric() || c == b'_';
-        if !value.is_empty() && value.iter().all(safe_char) && !is_quotable_keyword(value) {
+        let starts_with_identifier_char = value
+            .first()
+            .is_some_and(|c| c.is_ascii_alphabetic() || *c == b'_');
+        if starts_with_identifier_char && value.iter().all(safe_char) && !is_quotable_keyword(value)
+        {
             self.value.clone()
         } else {
             format!("\"{}\"", self.value.replace("\"", "\"\""))

--- a/tests/integration/query_processing/test_alter_table_reopen.rs
+++ b/tests/integration/query_processing/test_alter_table_reopen.rs
@@ -263,3 +263,206 @@ fn test_alter_table_add_column_preserves_collation_on_reopen() {
         conn.close().unwrap();
     }
 }
+
+#[test]
+fn test_alter_table_preserves_desc_primary_key_on_reopen() {
+    let temp_dir = TempDir::new().unwrap();
+    let path = temp_dir.path().join("alter_desc_pk_reopen.db");
+
+    {
+        let db = TempDatabase::new_with_existent(&path);
+        let conn = db.connect_limbo();
+        conn.execute("CREATE TABLE t(a INTEGER PRIMARY KEY DESC, q TEXT)")
+            .unwrap();
+        conn.execute("ALTER TABLE t ADD COLUMN z TEXT").unwrap();
+        let schema: Vec<(String,)> =
+            conn.exec_rows("SELECT sql FROM sqlite_schema WHERE name = 't'");
+        assert!(schema[0].0.contains("PRIMARY KEY DESC"), "{schema:?}");
+        conn.close().unwrap();
+    }
+
+    let db = TempDatabase::new_with_existent(&path);
+    let conn = db.connect_limbo();
+    conn.execute("INSERT INTO t(a, q, z) VALUES (1, 'q', 'z')")
+        .unwrap();
+    assert!(conn
+        .execute("INSERT INTO t(a, q, z) VALUES (1, 'duplicate', 'z')")
+        .is_err());
+    conn.close().unwrap();
+}
+
+#[test]
+fn test_alter_table_rename_quotes_digit_leading_name() {
+    let temp_dir = TempDir::new().unwrap();
+    let path = temp_dir.path().join("alter_rename_quoted_reopen.db");
+
+    {
+        let db = TempDatabase::new_with_existent(&path);
+        let conn = db.connect_limbo();
+        conn.execute("CREATE TABLE t(a)").unwrap();
+        conn.execute("CREATE INDEX i ON t(a)").unwrap();
+        conn.execute("ALTER TABLE t RENAME TO \"1a\"").unwrap();
+        let rows: Vec<(String,)> =
+            conn.exec_rows("SELECT sql FROM sqlite_schema WHERE name IN ('1a', 'i') ORDER BY name");
+        assert_eq!(rows.len(), 2);
+        assert!(rows.iter().all(|(sql,)| sql.contains("\"1a\"")), "{rows:?}");
+        conn.close().unwrap();
+    }
+
+    let db = TempDatabase::new_with_existent(&path);
+    let conn = db.connect_limbo();
+    conn.execute("INSERT INTO \"1a\" VALUES (1)").unwrap();
+    let rows: Vec<(i64,)> = conn.exec_rows("SELECT count(*) FROM \"1a\"");
+    assert_eq!(rows, vec![(1,)]);
+    conn.close().unwrap();
+}
+
+#[test]
+fn test_alter_table_omits_empty_foreign_key_parent_column_list() {
+    let temp_dir = TempDir::new().unwrap();
+    let path = temp_dir.path().join("alter_fk_parent_columns_reopen.db");
+
+    {
+        let db = TempDatabase::new_with_existent(&path);
+        let conn = db.connect_limbo();
+        conn.execute("CREATE TABLE p(id INTEGER PRIMARY KEY)")
+            .unwrap();
+        conn.execute("CREATE TABLE t(a INTEGER, FOREIGN KEY(a) REFERENCES p)")
+            .unwrap();
+        conn.execute("CREATE TABLE u(a INTEGER REFERENCES p, b INTEGER REFERENCES p(id))")
+            .unwrap();
+        conn.execute("ALTER TABLE t ADD COLUMN c INTEGER").unwrap();
+        conn.execute("ALTER TABLE u ADD COLUMN c INTEGER").unwrap();
+        let rows: Vec<(String,)> =
+            conn.exec_rows("SELECT sql FROM sqlite_schema WHERE name IN ('t', 'u') ORDER BY name");
+        assert!(
+            rows.iter().all(|(sql,)| !sql.contains("REFERENCES p()")),
+            "{rows:?}"
+        );
+        conn.close().unwrap();
+    }
+
+    let db = TempDatabase::new_with_existent(&path);
+    let conn = db.connect_limbo();
+    let t_rows: Vec<(i64,)> = conn.exec_rows("SELECT count(*) FROM t");
+    assert_eq!(t_rows, vec![(0,)]);
+    let u_rows: Vec<(i64,)> = conn.exec_rows("SELECT count(*) FROM u");
+    assert_eq!(u_rows, vec![(0,)]);
+    conn.close().unwrap();
+}
+
+#[test]
+fn test_alter_table_preserves_table_constraint_modifiers() {
+    let temp_dir = TempDir::new().unwrap();
+    let path = temp_dir.path().join("alter_constraint_modifiers_reopen.db");
+
+    {
+        let db = TempDatabase::new_with_existent(&path);
+        let conn = db.connect_limbo();
+        conn.execute("CREATE TABLE t(a TEXT, UNIQUE(a DESC))")
+            .unwrap();
+        conn.execute("CREATE TABLE u(a TEXT, UNIQUE(a COLLATE NOCASE))")
+            .unwrap();
+        conn.execute("CREATE TABLE p(a TEXT, b TEXT, PRIMARY KEY(a DESC, b COLLATE NOCASE))")
+            .unwrap();
+        conn.execute("ALTER TABLE t ADD COLUMN q TEXT").unwrap();
+        conn.execute("ALTER TABLE u ADD COLUMN q TEXT").unwrap();
+        conn.execute("ALTER TABLE p ADD COLUMN q TEXT").unwrap();
+        let rows: Vec<(String, String)> = conn.exec_rows(
+            "SELECT name, sql FROM sqlite_schema WHERE name IN ('t', 'u', 'p') ORDER BY name",
+        );
+        assert!(
+            rows.iter()
+                .any(|(name, sql)| name == "t" && sql.contains("UNIQUE (a DESC)")),
+            "{rows:?}"
+        );
+        assert!(
+            rows.iter()
+                .any(|(name, sql)| name == "u" && sql.contains("COLLATE NOCASE")),
+            "{rows:?}"
+        );
+        assert!(
+            rows.iter()
+                .any(|(name, sql)| name == "p"
+                    && sql.contains("PRIMARY KEY (a DESC, b COLLATE NOCASE)")),
+            "{rows:?}"
+        );
+        conn.close().unwrap();
+    }
+
+    let db = TempDatabase::new_with_existent(&path);
+    let conn = db.connect_limbo();
+    conn.execute("INSERT INTO t(a, q) VALUES ('a', 'x')")
+        .unwrap();
+    assert!(conn
+        .execute("INSERT INTO t(a, q) VALUES ('a', 'y')")
+        .is_err());
+    conn.execute("INSERT INTO u(a, q) VALUES ('ABC', 'x')")
+        .unwrap();
+    assert!(conn
+        .execute("INSERT INTO u(a, q) VALUES ('abc', 'y')")
+        .is_err());
+    conn.close().unwrap();
+}
+
+#[test]
+fn test_alter_table_preserves_on_conflict_rollback() {
+    let temp_dir = TempDir::new().unwrap();
+    let path = temp_dir.path().join("alter_conflict_reopen.db");
+
+    {
+        let db = TempDatabase::new_with_existent(&path);
+        let conn = db.connect_limbo();
+        conn.execute("CREATE TABLE t(id INTEGER, k TEXT UNIQUE ON CONFLICT ROLLBACK, x INTEGER)")
+            .unwrap();
+        conn.execute("ALTER TABLE t ADD COLUMN note TEXT").unwrap();
+        let rows: Vec<(String,)> = conn.exec_rows("SELECT sql FROM sqlite_schema WHERE name = 't'");
+        assert!(rows[0].0.contains("ON CONFLICT ROLLBACK"), "{rows:?}");
+        conn.close().unwrap();
+    }
+
+    let db = TempDatabase::new_with_existent(&path);
+    let conn = db.connect_limbo();
+    conn.execute("BEGIN").unwrap();
+    conn.execute("INSERT INTO t(id, k) VALUES (1, 'a')")
+        .unwrap();
+    assert!(conn
+        .execute("INSERT INTO t(id, k) VALUES (2, 'a')")
+        .is_err());
+    let rows: Vec<(i64,)> = conn.exec_rows("SELECT count(*) FROM t");
+    assert_eq!(rows, vec![(0,)]);
+    conn.close().unwrap();
+}
+
+#[test]
+fn test_alter_table_preserves_primary_key_and_unique_order() {
+    let temp_dir = TempDir::new().unwrap();
+    let path = temp_dir.path().join("alter_constraint_order_reopen.db");
+
+    {
+        let db = TempDatabase::new_with_existent(&path);
+        let conn = db.connect_limbo();
+        conn.execute("CREATE TABLE t(a TEXT, b TEXT, UNIQUE(a), PRIMARY KEY(b))")
+            .unwrap();
+        conn.execute("ALTER TABLE t ADD COLUMN d TEXT").unwrap();
+        let rows: Vec<(String,)> = conn.exec_rows("SELECT sql FROM sqlite_schema WHERE name = 't'");
+        let sql = &rows[0].0;
+        assert!(
+            sql.find("UNIQUE (a)").unwrap() < sql.find("PRIMARY KEY (b)").unwrap(),
+            "{sql}"
+        );
+        conn.close().unwrap();
+    }
+
+    let db = TempDatabase::new_with_existent(&path);
+    let conn = db.connect_limbo();
+    conn.execute("INSERT INTO t(a, b, d) VALUES ('a', 'b', 'd')")
+        .unwrap();
+    assert!(conn
+        .execute("INSERT INTO t(a, b, d) VALUES ('a', 'c', 'd')")
+        .is_err());
+    assert!(conn
+        .execute("INSERT INTO t(a, b, d) VALUES ('c', 'b', 'd')")
+        .is_err());
+    conn.close().unwrap();
+}


### PR DESCRIPTION
ALTER TABLE ADD/DROP rewrites CREATE TABLE SQL. Preserve inline versus table-level primary-key form, DESC and COLLATE modifiers, ON CONFLICT clauses, table-constraint order, and omit empty REFERENCES column lists. Quote renamed identifiers that begin with a digit so the rewritten schema remains reopenable.\n\nValidation: cargo check -p turso_core; cargo test -p turso_parser; cargo test -p core_tester --test integration_tests query_processing::test_alter_table_reopen::; cargo test -p turso_core schema::tests::; cargo fmt --all -- --check.\n\nFixes #8699, #8700, #8701, #8702, #8703, #8704.