### PR TITLE
bench: seed FTS segment layout for paired profiles

### DIFF
--- a/PERF.md
+++ b/PERF.md
@@ -31,6 +31,13 @@ preflight checks base row counts and FTS-vs-base matching IDs after each
 mutation. Query loops check expected cardinality; ranking correctness and
 snapshot isolation are checked independently by the Whopper suite.
 
+The benchmark's platform IO uses ChaCha8 seed `0xF75` for segment IDs and
+other IO randomness. Clocks, files, Completion handling and cancellation
+still use PlatformIO. Freezing document text alone is insufficient: random
+segment IDs change backing-key order and MVCC index traversal. This seed is
+benchmark-only, not a production random source. Compare binaries built with
+the same seeded harness; older unseeded profiles include layout variation.
+
 "Fresh connection" retains the shared database/index cache and OS page cache;
 it is **not cold storage**. "Engine cold" drops the setup database and opens
 it with a new IO instance; opening/recovery, query preparation and the first

--- a/core/benches/fts_benchmark.rs
+++ b/core/benches/fts_benchmark.rs
@@ -21,8 +21,11 @@ use codspeed_criterion_compat::{
     criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion,
 };
 
+use rand::{Rng, RngCore, SeedableRng};
+use rand_chacha::ChaCha8Rng;
 use std::sync::Arc;
 use tempfile::TempDir;
+use turso_core::io::{Clock, IO};
 use turso_core::{Database, DatabaseOpts, OpenFlags, PlatformIO, StepResult};
 
 #[cfg(not(target_family = "wasm"))]
@@ -97,7 +100,7 @@ fn setup_fts_db(temp_dir: &TempDir, row_count: usize) -> Arc<Database> {
 fn setup_fts_db_with_mode(temp_dir: &TempDir, row_count: usize, mvcc: bool) -> Arc<Database> {
     let db_path = temp_dir.path().join("fts_bench.db");
     #[allow(clippy::arc_with_non_send_sync)]
-    let io = Arc::new(PlatformIO::new().unwrap());
+    let io = Arc::new(SeededIO::new());
     let opts = DatabaseOpts::new().with_index_method(true);
     let db = Database::open_file_with_flags(
         io,
@@ -784,7 +787,7 @@ fn bench_fts_mvcc_reopen(criterion: &mut Criterion) {
             },
             |dir| {
                 #[allow(clippy::arc_with_non_send_sync)]
-                let io = Arc::new(PlatformIO::new().unwrap());
+                let io = Arc::new(SeededIO::new());
                 let db = Database::open_file_with_flags(
                     io,
                     dir.path().join("fts_bench.db").to_str().unwrap(),
@@ -807,6 +810,103 @@ fn bench_fts_mvcc_reopen(criterion: &mut Criterion) {
         );
     });
     group.finish();
+}
+
+// Segment IDs determine backing-key order. Freeze them without replacing real
+// storage, clocks, cancellation, or Completion handling with a simulator.
+struct SeededIO {
+    platform: PlatformIO,
+    rng: std::sync::Mutex<ChaCha8Rng>,
+}
+
+impl SeededIO {
+    fn new() -> Self {
+        Self {
+            platform: PlatformIO::new().unwrap(),
+            rng: std::sync::Mutex::new(ChaCha8Rng::seed_from_u64(0xF75)),
+        }
+    }
+}
+
+impl Clock for SeededIO {
+    fn current_time_monotonic(&self) -> turso_core::io::clock::MonotonicInstant {
+        self.platform.current_time_monotonic()
+    }
+
+    fn current_time_wall_clock(&self) -> turso_core::io::clock::WallClockInstant {
+        self.platform.current_time_wall_clock()
+    }
+}
+
+impl IO for SeededIO {
+    fn open_file(
+        &self,
+        path: &str,
+        flags: OpenFlags,
+        direct: bool,
+    ) -> turso_core::Result<Arc<dyn turso_core::File>> {
+        self.platform.open_file(path, flags, direct)
+    }
+
+    fn open_shared_wal_file(&self, path: &str) -> turso_core::Result<Arc<dyn turso_core::File>> {
+        self.platform.open_shared_wal_file(path)
+    }
+
+    fn remove_file(&self, path: &str) -> turso_core::Result<()> {
+        self.platform.remove_file(path)
+    }
+
+    fn supports_shared_wal_coordination(&self) -> bool {
+        self.platform.supports_shared_wal_coordination()
+    }
+
+    fn step(&self) -> turso_core::Result<()> {
+        self.platform.step()
+    }
+
+    fn cancel(&self, completions: &[turso_core::Completion]) -> turso_core::Result<()> {
+        self.platform.cancel(completions)
+    }
+
+    fn drain_completions(&self, completions: &[turso_core::Completion]) -> turso_core::Result<()> {
+        self.platform.drain_completions(completions)
+    }
+
+    fn wait_for_completion(&self, completion: turso_core::Completion) -> turso_core::Result<()> {
+        self.platform.wait_for_completion(completion)
+    }
+
+    fn generate_random_number(&self) -> i64 {
+        self.rng.lock().unwrap().random()
+    }
+
+    fn fill_bytes(&self, dest: &mut [u8]) {
+        self.rng.lock().unwrap().fill_bytes(dest);
+    }
+
+    fn get_memory_io(&self) -> Arc<turso_core::MemoryIO> {
+        self.platform.get_memory_io()
+    }
+
+    fn register_fixed_buffer(
+        &self,
+        ptr: std::ptr::NonNull<u8>,
+        len: usize,
+    ) -> turso_core::Result<u32> {
+        self.platform.register_fixed_buffer(ptr, len)
+    }
+
+    fn yield_now(&self) {
+        self.platform.yield_now();
+    }
+
+    fn sleep(&self, duration: std::time::Duration) {
+        self.platform.sleep(duration);
+    }
+
+    fn file_id(&self, path: &str) -> turso_core::Result<turso_core::io::FileId> {
+        self.platform.file_id(path)
+    }
 }
 
 #[cfg(not(feature = "codspeed"))]


### PR DESCRIPTION
## Description

Seed FTS benchmark IO randomness with ChaCha8 seed `0xF75`. Forward all storage, clock, cancellation, Completion, shared-WAL and file-identity operations to PlatformIO.

## Motivation and context

Deterministic document text did not freeze physical layout: random segment IDs change backing-key order and MVCC skiplist comparisons. Three optimized 50-segment profiles varied by roughly 2% before seeding. With the same seeded harness, baseline scoped counts are 22,365,984 / 22,371,197 / 22,382,317 instructions (<0.1% spread). Remaining process-level allocator/hash/address variation is not claimed deterministic.

This is benchmark-only preparation above #8875, not a production optimization, RNG change or build-policy change. Optimized measurements use the existing `bench-profile` under explicit user approval for this profiling pass.

## Verification

- `cargo build --profile bench-profile -p turso_core --bench fts_benchmark --features fts --locked`
- Built binary `--bench --test`: all 72 correctness cases passed.
- `cargo fmt`; `git diff --check`.
- Scoped Callgrind boundary: `--collect-atstart=no --toggle-collect=fts_benchmark::run_mvcc_query`, case `FTS MVCC/selective/rankedfalse/warm/rows5000/repeat1/batch100/optfalse`.
- Valgrind 3.19 simulated counters, Linux x64 Debian 12 orb, Rust 1.88, mimalloc; no hardware-counter or production-throughput claim.

## Description of AI Usage

Implemented and verified with Amp under user-directed profiling and reviewable-stack publication instructions.
