### PR TITLE
mvcc: compare index columns without singleton iterators

### DIFF
--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -26,7 +26,7 @@ use crate::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use crate::sync::Arc;
 use crate::sync::{Mutex, RwLock};
 use crate::translate::plan::IterationDirection;
-use crate::types::compare_immutable;
+use crate::types::cmp_in_column;
 use crate::types::IOCompletions;
 use crate::types::IOResult;
 use crate::types::IOResultOr;
@@ -226,11 +226,7 @@ impl SortableIndexKey {
             let lhs_value = lhs.next().expect("we already checked length")?;
             let rhs_value = rhs.next().expect("we already checked length")?;
 
-            let cmp = compare_immutable(
-                std::iter::once(&lhs_value),
-                std::iter::once(&rhs_value),
-                &self.metadata.key_info[i..i + 1],
-            );
+            let cmp = cmp_in_column(&lhs_value, &rhs_value, &self.metadata.key_info[i]);
 
             if cmp != std::cmp::Ordering::Equal {
                 return Ok(cmp);
@@ -272,11 +268,7 @@ impl SortableIndexKey {
                 None => return Ok(false),
             };
 
-            let cmp = compare_immutable(
-                std::iter::once(&lhs_value),
-                std::iter::once(&rhs_value),
-                &self.metadata.key_info[i..i + 1],
-            );
+            let cmp = cmp_in_column(&lhs_value, &rhs_value, &self.metadata.key_info[i]);
 
             if cmp != std::cmp::Ordering::Equal {
                 return Ok(false);

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -381,6 +381,123 @@ fn row_payload_allocation_uses_passed_allocator() {
     assert_eq!(row.payload(), &[1, 2, 3]);
 }
 
+#[test]
+fn index_key_ordering_preserves_collation_direction_nulls_and_prefixes() {
+    use crate::translate::collate::CollationSeq;
+    use crate::types::KeyInfo;
+    use std::cmp::Ordering::{Equal, Greater, Less};
+    use turso_parser::ast::{NullsOrder, SortOrder};
+
+    let key = |values: &[Value], columns: &[KeyInfo]| {
+        let record = ImmutableRecord::from_values(values, values.len()).unwrap();
+        SortableIndexKey::new_from_payload_in(
+            &record,
+            Arc::new(IndexInfo::new(columns.iter().copied(), false, columns.len(), false).unwrap()),
+            TursoAllocator,
+        )
+        .unwrap()
+    };
+    for (collation, left, right, ascending) in [
+        (CollationSeq::Binary, "Zebra", "apple", Less),
+        (CollationSeq::NoCase, "Zebra", "apple", Greater),
+        (CollationSeq::NoCase, "APPLE", "apple", Equal),
+        (CollationSeq::Rtrim, "apple   ", "apple", Equal),
+        (CollationSeq::Binary, "apple   ", "apple", Greater),
+    ] {
+        for direction in [SortOrder::Asc, SortOrder::Desc] {
+            let columns = [KeyInfo {
+                sort_order: direction,
+                collation,
+                nulls_order: None,
+            }];
+            let lhs = key(&[Value::build_text(left)], &columns);
+            let rhs = key(&[Value::build_text(right)], &columns);
+            let expected = if direction == SortOrder::Asc {
+                ascending
+            } else {
+                ascending.reverse()
+            };
+            assert_eq!(lhs.compare(&rhs).unwrap(), expected);
+            assert_eq!(rhs.compare(&lhs).unwrap(), expected.reverse());
+            assert_eq!(lhs.matches_prefix(&rhs, 1).unwrap(), expected == Equal);
+        }
+    }
+    for (left, right, ascending) in [
+        (Value::from_i64(7), Value::from_f64(7.0), Equal),
+        (Value::from_i64(-3), Value::from_f64(-2.5), Less),
+        (Value::from_i64(99), Value::build_text("1"), Less),
+        (
+            Value::build_text("z"),
+            Value::from_blob(vec![0].into()),
+            Less,
+        ),
+        (
+            Value::from_blob(vec![0, 255].into()),
+            Value::from_blob(vec![1].into()),
+            Less,
+        ),
+    ] {
+        for direction in [SortOrder::Asc, SortOrder::Desc] {
+            let columns = [KeyInfo {
+                sort_order: direction,
+                collation: CollationSeq::NoCase,
+                nulls_order: None,
+            }];
+            let lhs = key(std::slice::from_ref(&left), &columns);
+            let rhs = key(std::slice::from_ref(&right), &columns);
+            let expected = if direction == SortOrder::Asc {
+                ascending
+            } else {
+                ascending.reverse()
+            };
+            assert_eq!(lhs.compare(&rhs).unwrap(), expected);
+            assert_eq!(rhs.compare(&lhs).unwrap(), expected.reverse());
+            assert_eq!(lhs.matches_prefix(&rhs, 1).unwrap(), expected == Equal);
+        }
+    }
+    for direction in [SortOrder::Asc, SortOrder::Desc] {
+        for nulls_order in [None, Some(NullsOrder::First), Some(NullsOrder::Last)] {
+            let columns = [KeyInfo {
+                sort_order: direction,
+                collation: CollationSeq::Binary,
+                nulls_order,
+            }];
+            let lhs = key(&[Value::Null], &columns);
+            let rhs = key(&[Value::from_i64(-3)], &columns);
+            let expected = match nulls_order {
+                Some(NullsOrder::First) => Less,
+                Some(NullsOrder::Last) => Greater,
+                None if direction == SortOrder::Asc => Less,
+                None => Greater,
+            };
+            assert_eq!(lhs.compare(&rhs).unwrap(), expected);
+            assert_eq!(rhs.compare(&lhs).unwrap(), expected.reverse());
+            assert!(!lhs.matches_prefix(&rhs, 1).unwrap());
+        }
+    }
+    let columns = [
+        KeyInfo {
+            sort_order: SortOrder::Asc,
+            collation: CollationSeq::NoCase,
+            nulls_order: None,
+        },
+        KeyInfo {
+            sort_order: SortOrder::Desc,
+            collation: CollationSeq::Binary,
+            nulls_order: None,
+        },
+    ];
+    let lhs = key(&[Value::build_text("APPLE"), Value::from_i64(2)], &columns);
+    let rhs = key(&[Value::build_text("apple"), Value::from_i64(9)], &columns);
+    let prefix = key(&[Value::build_text("Apple")], &columns[..1]);
+    assert_eq!(lhs.compare(&rhs).unwrap(), Greater);
+    assert!(lhs.matches_prefix(&rhs, 1).unwrap());
+    assert!(!lhs.matches_prefix(&rhs, 2).unwrap());
+    assert_eq!(lhs.compare(&prefix).unwrap(), Equal);
+    assert_eq!(prefix.compare(&lhs).unwrap(), Equal);
+    assert!(!prefix.matches_prefix(&lhs, 2).unwrap());
+}
+
 #[cfg(nightly)]
 #[test]
 fn index_key_payload_allocation_uses_passed_allocator() {

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -428,12 +428,12 @@ fn index_key_ordering_preserves_collation_direction_nulls_and_prefixes() {
         (Value::from_i64(99), Value::build_text("1"), Less),
         (
             Value::build_text("z"),
-            Value::from_blob(vec![0].into()),
+            Value::from_blob(crate::alloc::vec![0]),
             Less,
         ),
         (
-            Value::from_blob(vec![0, 255].into()),
-            Value::from_blob(vec![1].into()),
+            Value::from_blob(crate::alloc::vec![0, 255]),
+            Value::from_blob(crate::alloc::vec![1]),
             Less,
         ),
     ] {


### PR DESCRIPTION
## Description

Use `cmp_in_column` directly for each MVCC index-key column instead of wrapping already-decoded values in singleton iterators for `compare_immutable`. The latter calls the same primitive. Preserve prefix length, collation, ASC/DESC and NULL semantics; no storage, caching, allocation or lifetime changes.

## Measured evidence

Baseline and candidate use identical #8878 seeded FTS fixtures (ChaCha8 `0xF75`), existing `bench-profile` (optimized + debug symbols, no LTO), Rust 1.88, mimalloc, Debian 12 Linux x64 four-CPU orb. This profile was explicitly authorized for this pass; no unrestricted release builds.

Scoped Callgrind, selective unranked warm query, 5,000 documents / 50 segments / no OPTIMIZE:

| Three runs | Baseline | Candidate |
|---|---|---|
| Instructions | 22,365,984 / 22,371,197 / 22,382,317 | 21,554,612 / 21,540,682 / 21,529,704 |
| Median conditional branch misses | 189,073 | 174,737 |

About 3.7% fewer simulated instructions. Cache evidence is mixed; these are Valgrind 3.19 simulated events, not hardware counters. Nested inclusive attribution is not summed.

Four alternating baseline/candidate timing pairs, 14 representative cases, 0.5s warmup / 2s measurement / 30 samples (write group overrides to 10), same frozen binaries:
- 50-segment selective median of session estimates: 2.8454ms → 2.69585ms (-5.3%).
- Other case median changes span -5.1% to +2.7%, with overlapping session variation. No across-the-board throughput claim.
- Existing non-FTS `record_recycling` target: four alternating pairs, 20 samples each. MVCC indexed-seek session medians 4.281/4.504/4.303/4.295ms → 4.348/4.264/4.214/4.194ms. Allocation count15,367 and requested3.574MB per iteration unchanged.

Query profiling boundary excludes fixture/preflight and includes prepare, execution/count validation and statement cleanup:
`valgrind --tool=callgrind --collect-atstart=no --toggle-collect=fts_benchmark::run_mvcc_query --cache-sim=yes --branch-sim=yes --I1=32768,8,64 --D1=32768,8,64 --LL=8388608,16,64 BINARY --bench 'FTS MVCC/selective/rankedfalse/warm/rows5000/repeat1/batch100/optfalse' --test`.

## Correctness

- Direct ordering cases: mixed storage types, integer/real equivalence, Binary/NoCase/Rtrim, ASC/DESC, NULLS FIRST/LAST, mixed-column order, unequal/prefix keys; independent expected results.
- `cargo test -p turso_core --lib --features fts mvcc::database::tests`:379 passed,6 ignored.
- FTS unit tests28 passed; `core_tester` index-method integration117 passed (including delayed output failure/cancellation/rollback).
- Whopper FTS regressions2 passed: six connections,12,000 steps, seeds0xF75/0xF7501/0xF7502, byte-exact first-seed replay; snapshot/merge/savepoint/rollback/recovery fixed interleaving.
- Seeded benchmark72 correctness cases passed.
- Initial CI found a test-only blob allocation mistake; follow-up uses `crate::alloc::vec!`. Nightly check and targeted test passed after correction. Stable Clippy reports only the pre-existing local JSON-cache lint expectation warning; actual new-head CI is tracked separately.

Raw logs/profiles: `/tmp/fts-profiles/seeded-column-ir-*`, `seeded-paired-column-*`, `nonfts-pair-*`, `column-{mvcc-tests,index-integration,whopper,nightly-fixed,clippy-fixed}.log` in the profiling thread.

## Description of AI Usage

Implemented, profiled and verified with Amp under user-directed optimization and reviewable-stack publication instructions.
