### PR TITLE
Fix NULL computed bounds for index seeks

### DIFF
--- a/core/translate/optimizer/mod.rs
+++ b/core/translate/optimizer/mod.rs
@@ -3418,7 +3418,14 @@ impl Optimizable for ast::Expr {
             Expr::Between {
                 lhs, start, end, ..
             } => lhs.is_nonnull(tables) && start.is_nonnull(tables) && end.is_nonnull(tables),
-            Expr::Binary(_, ast::Operator::Modulus | ast::Operator::Divide, _) => false, // 1 % 0, 1 / 0
+            Expr::Binary(
+                _,
+                ast::Operator::Modulus
+                | ast::Operator::Divide
+                | ast::Operator::ArrowRight
+                | ast::Operator::ArrowRightShift,
+                _,
+            ) => false, // These operators can yield NULL (including on a missing JSON path).
             Expr::Binary(expr, _, expr1) => expr.is_nonnull(tables) && expr1.is_nonnull(tables),
             Expr::Case {
                 when_then_pairs,
@@ -3473,7 +3480,15 @@ impl Optimizable for ast::Expr {
             Expr::InSelect { .. } => false,
             Expr::InTable { .. } => false,
             Expr::IsNull(..) => true,
-            Expr::Like { lhs, rhs, .. } => lhs.is_nonnull(tables) && rhs.is_nonnull(tables),
+            Expr::Like {
+                lhs, rhs, escape, ..
+            } => {
+                lhs.is_nonnull(tables)
+                    && rhs.is_nonnull(tables)
+                    && escape
+                        .as_ref()
+                        .is_none_or(|escape| escape.is_nonnull(tables))
+            }
             Expr::Literal(literal) => match literal {
                 ast::Literal::Numeric(_) => true,
                 ast::Literal::String(_) => true,

--- a/sqlite/conformance/sqlite-sqltests/index-seek-null-computed-bound.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/index-seek-null-computed-bound.sqltest
@@ -52,3 +52,29 @@ test case-with-else-bounds-normally {
 expect {
     2
 }
+
+# LIKE with a NULL ESCAPE evaluates to NULL. The seek must guard the
+# computed bound instead of starting at the NULL key and scanning the index.
+@cross-check-integrity
+test like-null-escape-bound-is-null {
+    CREATE TABLE t(c);
+    CREATE INDEX i ON t(c);
+    INSERT INTO t VALUES (1), (2), (3);
+    SELECT count(*) FROM t WHERE c > ('a' LIKE 'a' ESCAPE NULL);
+}
+expect {
+    0
+}
+
+# JSON arrow operators return NULL for a missing path. The index range must
+# remain empty just as it is without an index.
+@cross-check-integrity
+test json-arrow-missing-path-bound-is-null {
+    CREATE TABLE t(c);
+    CREATE INDEX i ON t(c);
+    INSERT INTO t VALUES (1), (2), (3);
+    SELECT count(*) FROM t WHERE c > ('{"k":1}' ->> '$.missing');
+}
+expect {
+    0
+}


### PR DESCRIPTION
## Summary

Computed seek bounds that can evaluate to NULL must take the empty range, matching SQLite. The optimizer previously treated JSON arrow operators and LIKE with a nullable ESCAPE as non-null and skipped the IsNull seek guard.

## Changes

- Treat -> and ->> expressions as nullable for seek-guard analysis.
- Include the optional LIKE ESCAPE expression in nullability analysis.
- Add SQLite cross-check regressions for both cases.

Fixes #8690

## Validation

- cargo fmt --all -- --check
- cargo run -p sqltest -- run sqlite/conformance/sqlite-sqltests/index-seek-null-computed-bound.sqltest --backend rust (6 passed)