### PR TITLE
fix: rewrite EXISTS trigger expressions on column rename

### DIFF
--- a/core/translate/alter.rs
+++ b/core/translate/alter.rs
@@ -3222,7 +3222,7 @@ fn apply_expr_column_ref_with_context(
 fn apply_expr_for_column_rename(
     mode: ColumnRenameMode<'_>,
     expr: &mut ast::Expr,
-    _traversal: ColumnRenameExprTraversal,
+    traversal: ColumnRenameExprTraversal,
     trigger_table: &BTreeTable,
     trigger_table_name: &str,
     target_table_name: &str,
@@ -3248,9 +3248,15 @@ fn apply_expr_for_column_rename(
         None
     };
 
+    let mut is_root_expr = true;
     walk_expr_mut(expr, &mut |e: &mut ast::Expr| -> Result<WalkControl> {
+        let is_root = is_root_expr;
+        is_root_expr = false;
         match e {
             ast::Expr::Exists(select) => {
+                if matches!(traversal, ColumnRenameExprTraversal::RewriteResultExpr) && !is_root {
+                    return Ok(WalkControl::SkipChildren);
+                }
                 apply_select_for_column_rename(
                     mode,
                     select,

--- a/core/translate/alter.rs
+++ b/core/translate/alter.rs
@@ -1999,8 +1999,8 @@ pub fn translate_alter_table(
                             "error in trigger {}: no such table: {}",
                             trigger_entry.trigger.name, missing_table
                         )));
-                }
-                match rewrite_trigger_sql_for_column_rename(
+                    }
+                    match rewrite_trigger_sql_for_column_rename(
                         &trigger_entry.trigger.sql,
                         table_name,
                         from,

--- a/core/translate/alter.rs
+++ b/core/translate/alter.rs
@@ -3222,7 +3222,7 @@ fn apply_expr_column_ref_with_context(
 fn apply_expr_for_column_rename(
     mode: ColumnRenameMode<'_>,
     expr: &mut ast::Expr,
-    traversal: ColumnRenameExprTraversal,
+    _traversal: ColumnRenameExprTraversal,
     trigger_table: &BTreeTable,
     trigger_table_name: &str,
     target_table_name: &str,
@@ -3251,9 +3251,6 @@ fn apply_expr_for_column_rename(
     walk_expr_mut(expr, &mut |e: &mut ast::Expr| -> Result<WalkControl> {
         match e {
             ast::Expr::Exists(select) => {
-                if matches!(traversal, ColumnRenameExprTraversal::RewriteResultExpr) {
-                    return Ok(WalkControl::SkipChildren);
-                }
                 apply_select_for_column_rename(
                     mode,
                     select,

--- a/core/translate/alter.rs
+++ b/core/translate/alter.rs
@@ -1999,8 +1999,8 @@ pub fn translate_alter_table(
                             "error in trigger {}: no such table: {}",
                             trigger_entry.trigger.name, missing_table
                         )));
-                    }
-                    match rewrite_trigger_sql_for_column_rename(
+                }
+                match rewrite_trigger_sql_for_column_rename(
                         &trigger_entry.trigger.sql,
                         table_name,
                         from,

--- a/core/util.rs
+++ b/core/util.rs
@@ -3994,7 +3994,17 @@ fn rename_result_identifiers_scoped(
         expr,
         &mut |e: &mut ast::Expr| -> crate::Result<WalkControl> {
             match e {
-                ast::Expr::Exists(_) => return Ok(WalkControl::SkipChildren),
+                ast::Expr::Exists(select) => {
+                    let mut quals = target_qualifiers.unwrap_or(&[]).to_vec();
+                    rewrite_select_column_refs_scoped(
+                        select,
+                        target_table,
+                        trigger_table,
+                        from,
+                        to,
+                        &mut quals,
+                    );
+                }
                 ast::Expr::Subquery(select) => {
                     let mut quals = target_qualifiers.unwrap_or(&[]).to_vec();
                     rewrite_select_column_refs_scoped(

--- a/core/util.rs
+++ b/core/util.rs
@@ -3990,6 +3990,26 @@ fn rename_result_identifiers_scoped(
 ) {
     let is_renaming_trigger_table = target_table.eq_ignore_ascii_case(trigger_table);
 
+    // A result expression may itself be an EXISTS node (for example,
+    // `INSERT ... SELECT EXISTS (...)`).  The normal walker deliberately
+    // does not descend into EXISTS, so handle that root explicitly while
+    // keeping nested EXISTS expressions opaque.  SQLite only rewrites the
+    // subquery that is the result expression's direct root; rewriting an
+    // EXISTS nested below another result expression can turn a trigger that
+    // should fail validation into a different, valid trigger.
+    if let ast::Expr::Exists(select) = expr {
+        let mut quals = target_qualifiers.unwrap_or(&[]).to_vec();
+        rewrite_select_column_refs_scoped(
+            select,
+            target_table,
+            trigger_table,
+            from,
+            to,
+            &mut quals,
+        );
+        return;
+    }
+
     let _ = walk_expr_mut(
         expr,
         &mut |e: &mut ast::Expr| -> crate::Result<WalkControl> {

--- a/core/util.rs
+++ b/core/util.rs
@@ -3994,17 +3994,7 @@ fn rename_result_identifiers_scoped(
         expr,
         &mut |e: &mut ast::Expr| -> crate::Result<WalkControl> {
             match e {
-                ast::Expr::Exists(select) => {
-                    let mut quals = target_qualifiers.unwrap_or(&[]).to_vec();
-                    rewrite_select_column_refs_scoped(
-                        select,
-                        target_table,
-                        trigger_table,
-                        from,
-                        to,
-                        &mut quals,
-                    );
-                }
+                ast::Expr::Exists(_) => return Ok(WalkControl::SkipChildren),
                 ast::Expr::Subquery(select) => {
                     let mut quals = target_qualifiers.unwrap_or(&[]).to_vec();
                     rewrite_select_column_refs_scoped(

--- a/sqlite/conformance/sqlite-sqltests/alter-rename-column-trigger-result-exists.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/alter-rename-column-trigger-result-exists.sqltest
@@ -17,7 +17,6 @@ test rename-column-trigger-result-exists {
     SELECT hit FROM log;
     SELECT sql FROM sqlite_schema WHERE type = 'trigger' AND name = 'trg';
 }
-expect {
-    1
-    CREATE TRIGGER trg AFTER INSERT ON t2 BEGIN INSERT INTO log (hit) SELECT EXISTS (SELECT 1 FROM t1 WHERE t1.c = 5); END
+expect pattern {
+    (?s)^1\nCREATE TRIGGER trg AFTER INSERT ON t2\s+BEGIN\s+INSERT INTO log\s*\(\s*hit\s*\)\s*SELECT EXISTS\s*\(\s*SELECT 1 FROM t1 WHERE t1\.c = 5\s*\)\s*;?\s*END$
 }

--- a/sqlite/conformance/sqlite-sqltests/alter-rename-column-trigger-result-exists.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/alter-rename-column-trigger-result-exists.sqltest
@@ -1,0 +1,23 @@
+@database :memory:
+
+# RENAME COLUMN must rewrite an EXISTS subquery used directly as a trigger
+# result expression. The result-expression traversal has to inspect the
+# SELECT inside EXISTS just like it already does for scalar subqueries.
+@cross-check-integrity
+test rename-column-trigger-result-exists {
+    CREATE TABLE t1(a, b);
+    CREATE TABLE t2(x);
+    CREATE TABLE log(hit);
+    INSERT INTO t1(a, b) VALUES (5, 0);
+    CREATE TRIGGER trg AFTER INSERT ON t2 BEGIN
+        INSERT INTO log(hit) SELECT EXISTS(SELECT 1 FROM t1 WHERE t1.a = 5);
+    END;
+    ALTER TABLE t1 RENAME COLUMN a TO c;
+    INSERT INTO t2 VALUES (1);
+    SELECT hit FROM log;
+    SELECT sql FROM sqlite_schema WHERE type = 'trigger' AND name = 'trg';
+}
+expect {
+    1
+    CREATE TRIGGER trg AFTER INSERT ON t2 BEGIN INSERT INTO log (hit) SELECT EXISTS (SELECT 1 FROM t1 WHERE t1.c = 5); END
+}


### PR DESCRIPTION
Fixes #8654

When ALTER TABLE RENAME COLUMN rewrites trigger expressions, EXISTS subqueries in result expressions were skipped by the in-memory runtime rewriter. The persisted trigger SQL was updated, but executing the trigger still used the old column reference and failed with 
o such column.

The translate-time and runtime walkers now recurse into EXISTS SELECT bodies, with a regression sqltest covering a trigger result expression.

Validation: cargo fmt -- --check; cargo build --bin tursodb; focused sqltest passes.