### PR TITLE
fix: retain CTE dependencies in IN lhs subqueries

### DIFF
--- a/core/translate/planner.rs
+++ b/core/translate/planner.rs
@@ -477,7 +477,11 @@ fn collect_subquery_table_refs_in_expr(expr: &Expr, out: &mut Vec<String>) {
             }
             Expr::InSelect { rhs, .. } => {
                 collect_from_clause_table_refs(rhs, out);
-                Ok(WalkControl::SkipChildren)
+                // The expression on the left-hand side can contain scalar
+                // subqueries that reference earlier CTEs. Keep walking it
+                // after collecting the right-hand SELECT so those
+                // dependencies are not dropped.
+                Ok(WalkControl::Continue)
             }
             _ => Ok(WalkControl::Continue),
         }

--- a/sqlite/conformance/sqlite-sqltests/cte-dependency-in-lhs-in.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/cte-dependency-in-lhs-in.sqltest
@@ -1,0 +1,13 @@
+@database :memory:
+
+# A scalar subquery in the left side of IN must keep its CTE dependency.
+test cte-dependency-in-lhs-in {
+    CREATE TABLE t(x INTEGER);
+    INSERT INTO t VALUES (100);
+    WITH a AS (SELECT 1 AS v),
+         b AS (SELECT 42 AS w FROM t WHERE (SELECT v FROM a) IN (SELECT 1))
+    SELECT * FROM b;
+}
+expect {
+    42
+}


### PR DESCRIPTION
Fixes #8655

The planner's CTE dependency collector handled the SELECT on the right side of xpr IN (SELECT ...) but stopped the expression walk before visiting the left side. A scalar subquery in that left expression could therefore lose its dependency and resolve against the schema.

The collector now continues after collecting the right-hand SELECT. A regression sqltest covers a left-side scalar subquery referencing an earlier CTE.

Validation: pre-fix regression failed with Parse error: no such table: a; cargo fmt -- --check; cargo build --bin tursodb; focused sqltest passes.