### PR TITLE
fix: preserve last insert rowid across window buffering

### DIFF
--- a/core/translate/window.rs
+++ b/core/translate/window.rs
@@ -2100,7 +2100,9 @@ fn emit_insert_row_into_buffer(
         cursor: cursors.csr_write,
         key_reg: registers.rowid,
         record_reg: reg_record,
-        flag: InsertFlags::new().require_seek(),
+        flag: InsertFlags::new()
+            .require_seek()
+            .is_ephemeral_table_insert(),
         table_name: table_name.to_string(),
     });
 }

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/windows/snapshots/windows__aggregate-windows.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/windows/snapshots/windows__aggregate-windows.snap
@@ -57,13 +57,13 @@ addr  opcode                  p1   p2  p3  p4                     p5  comment
   27            Null           0   15  18                          0  r[15..18]=NULL; reset accumulator registers
   28            MakeRecord     3    4  31                          0  r[31]=mkrec(r[3..6])
   29            NewRowid       3   27   0                          0  r[27]=rowid
-  30            Insert         3   31  27  buffer_table_window_1   2  intkey=r[27] data=r[31]
+  30            Insert         3   31  27  buffer_table_window_1   6  intkey=r[27] data=r[31]
   31            Rewind         2   33   0                          0  Rewind  ephemeral(buffer_table_window_1)
   32            Rewind         4   33   0                          0  Rewind  ephemeral(buffer_table_window_1)
   33            Goto           0   60   0                          0
   34            MakeRecord     3    4  32                          0  r[32]=mkrec(r[3..6])
   35            NewRowid       3   27   0                          0  r[27]=rowid
-  36            Insert         3   32  27  buffer_table_window_1   2  intkey=r[27] data=r[32]
+  36            Insert         3   32  27  buffer_table_window_1   6  intkey=r[27] data=r[32]
   37            Goto           0   60   0                          0  ; peer of previous row: buffer only, handle at group end
   38            AggStep        0   33  15  count                   0  accum=r[15] step(r[33])
   39            Column         4    3  34                          0  r[34]=ephemeral(buffer_table_window_1).salary
@@ -137,13 +137,13 @@ addr  opcode                  p1   p2  p3  p4                     p5  comment
  107        Null               0   50  50                          0  r[50..50]=NULL; reset accumulator registers
  108        MakeRecord         7    8  63                          0  r[63]=mkrec(r[7..14])
  109        NewRowid           6   60   0                          0  r[60]=rowid
- 110        Insert             6   63  60  buffer_table_window_0   2  intkey=r[60] data=r[63]
+ 110        Insert             6   63  60  buffer_table_window_0   6  intkey=r[60] data=r[63]
  111        Rewind             5  113   0                          0  Rewind  ephemeral(buffer_table_window_0)
  112        Rewind             7  113   0                          0  Rewind  ephemeral(buffer_table_window_0)
  113        Goto               0  129   0                          0
  114        MakeRecord         7    8  64                          0  r[64]=mkrec(r[7..14])
  115        NewRowid           6   60   0                          0  r[60]=rowid
- 116        Insert             6   64  60  buffer_table_window_0   2  intkey=r[60] data=r[64]
+ 116        Insert             6   64  60  buffer_table_window_0   6  intkey=r[60] data=r[64]
  117        Goto               0  129   0                          0  ; peer of previous row: buffer only, handle at group end
  118        AggStep            0   65  50  count                   0  accum=r[50] step(r[65])
  119        Next               7  121   0                          0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/windows/snapshots/windows__multiple-windows.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/windows/snapshots/windows__multiple-windows.snap
@@ -75,13 +75,13 @@ addr  opcode                           p1   p2   p3  p4                     p5  
   35                    Null            0   20   20                          0  r[20..20]=NULL; reset accumulator registers
   36                    MakeRecord      5    6   32                          0  r[32]=mkrec(r[5..10])
   37                    NewRowid        5   28    0                          0  r[28]=rowid
-  38                    Insert          5   32   28  buffer_table_window_3   2  intkey=r[28] data=r[32]
+  38                    Insert          5   32   28  buffer_table_window_3   6  intkey=r[28] data=r[32]
   39                    Rewind          4   41    0                          0  Rewind  ephemeral(buffer_table_window_3)
   40                    Rewind          6   41    0                          0  Rewind  ephemeral(buffer_table_window_3)
   41                    Goto            0   60    0                          0
   42                    MakeRecord      5    6   33                          0  r[33]=mkrec(r[5..10])
   43                    NewRowid        5   28    0                          0  r[28]=rowid
-  44                    Insert          5   33   28  buffer_table_window_3   2  intkey=r[28] data=r[33]
+  44                    Insert          5   33   28  buffer_table_window_3   6  intkey=r[28] data=r[33]
   45                    Goto            0   60    0                          0  ; peer of previous row: buffer only, handle at group end
   46                    Column          6    3   34                          0  r[34]=ephemeral(buffer_table_window_3).salary
   47                    AggStep         0   34   20  avg                     0  accum=r[20] step(r[34])
@@ -152,13 +152,13 @@ addr  opcode                           p1   p2   p3  p4                     p5  
  112                Null                0   52   52                          0  r[52..52]=NULL; reset accumulator registers
  113                MakeRecord         12    7   65                          0  r[65]=mkrec(r[12..18])
  114                NewRowid           10   61    0                          0  r[61]=rowid
- 115                Insert             10   65   61  buffer_table_window_2   2  intkey=r[61] data=r[65]
+ 115                Insert             10   65   61  buffer_table_window_2   6  intkey=r[61] data=r[65]
  116                Rewind              9  118    0                          0  Rewind  ephemeral(buffer_table_window_2)
  117                Rewind             11  118    0                          0  Rewind  ephemeral(buffer_table_window_2)
  118                Goto                0  137    0                          0
  119                MakeRecord         12    7   66                          0  r[66]=mkrec(r[12..18])
  120                NewRowid           10   61    0                          0  r[61]=rowid
- 121                Insert             10   66   61  buffer_table_window_2   2  intkey=r[61] data=r[66]
+ 121                Insert             10   66   61  buffer_table_window_2   6  intkey=r[61] data=r[66]
  122                Goto                0  137    0                          0  ; peer of previous row: buffer only, handle at group end
  123                Column             11    2   67                          0  r[67]=ephemeral(buffer_table_window_2).amount
  124                AggStep             0   67   52  sum                     0  accum=r[52] step(r[67])
@@ -231,13 +231,13 @@ addr  opcode                           p1   p2   p3  p4                     p5  
  191            Null                    0   87   87                          0  r[87..87]=NULL; reset accumulator registers
  192            MakeRecord             43    8  102                          0  r[102]=mkrec(r[43..50])
  193            NewRowid               15   97    0                          0  r[97]=rowid
- 194            Insert                 15  102   97  buffer_table_window_1   2  intkey=r[97] data=r[102]
+ 194            Insert                 15  102   97  buffer_table_window_1   6  intkey=r[97] data=r[102]
  195            Rewind                 14  197    0                          0  Rewind  ephemeral(buffer_table_window_1)
  196            Rewind                 16  197    0                          0  Rewind  ephemeral(buffer_table_window_1)
  197            Goto                    0  211    0                          0
  198            MakeRecord             43    8  103                          0  r[103]=mkrec(r[43..50])
  199            NewRowid               15   97    0                          0  r[97]=rowid
- 200            Insert                 15  103   97  buffer_table_window_1   2  intkey=r[97] data=r[103]
+ 200            Insert                 15  103   97  buffer_table_window_1   6  intkey=r[97] data=r[103]
  201            AggStep                 0    0   87  row_number              0  accum=r[87] step(r[0])
  202            Next                   16  203    0                          0
  203            AggValue                0   87   88  row_number              0  accum=r[87] dest=r[88]
@@ -302,13 +302,13 @@ addr  opcode                           p1   p2   p3  p4                     p5  
  262        Null                        0  123  123                          0  r[123..123]=NULL; reset accumulator registers
  263        MakeRecord                 77    9  139                          0  r[139]=mkrec(r[77..85])
  264        NewRowid                   19  134    0                          0  r[134]=rowid
- 265        Insert                     19  139  134  buffer_table_window_0   2  intkey=r[134] data=r[139]
+ 265        Insert                     19  139  134  buffer_table_window_0   6  intkey=r[134] data=r[139]
  266        Rewind                     18  268    0                          0  Rewind  ephemeral(buffer_table_window_0)
  267        Rewind                     20  268    0                          0  Rewind  ephemeral(buffer_table_window_0)
  268        Goto                        0  281    0                          0
  269        MakeRecord                 77    9  140                          0  r[140]=mkrec(r[77..85])
  270        NewRowid                   19  134    0                          0  r[134]=rowid
- 271        Insert                     19  140  134  buffer_table_window_0   2  intkey=r[134] data=r[140]
+ 271        Insert                     19  140  134  buffer_table_window_0   6  intkey=r[134] data=r[140]
  272        AggStep                     0    0  123  row_number              0  accum=r[123] step(r[0])
  273        Next                       20  274    0                          0
  274        AggValue                    0  123  124  row_number              0  accum=r[123] dest=r[124]

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/windows/snapshots/windows__percent-of-total.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/windows/snapshots/windows__percent-of-total.snap
@@ -54,13 +54,13 @@ addr  opcode                  p1   p2  p3  p4                     p5  comment
   27            Null           0   12  12                          0  r[12..12]=NULL; reset accumulator registers
   28            MakeRecord     3    4  22                          0  r[22]=mkrec(r[3..6])
   29            NewRowid       3   18   0                          0  r[18]=rowid
-  30            Insert         3   22  18  buffer_table_window_1   2  intkey=r[18] data=r[22]
+  30            Insert         3   22  18  buffer_table_window_1   6  intkey=r[18] data=r[22]
   31            Rewind         2   33   0                          0  Rewind  ephemeral(buffer_table_window_1)
   32            Rewind         4   33   0                          0  Rewind  ephemeral(buffer_table_window_1)
   33            Goto           0   52   0                          0
   34            MakeRecord     3    4  23                          0  r[23]=mkrec(r[3..6])
   35            NewRowid       3   18   0                          0  r[18]=rowid
-  36            Insert         3   23  18  buffer_table_window_1   2  intkey=r[18] data=r[23]
+  36            Insert         3   23  18  buffer_table_window_1   6  intkey=r[18] data=r[23]
   37            Goto           0   52   0                          0  ; peer of previous row: buffer only, handle at group end
   38            Column         4    3  24                          0  r[24]=ephemeral(buffer_table_window_1).salary
   39            AggStep        0   24  12  sum                     0  accum=r[12] step(r[24])
@@ -115,13 +115,13 @@ addr  opcode                  p1   p2  p3  p4                     p5  comment
   88        Null               0   32  32                          0  r[32..32]=NULL; reset accumulator registers
   89        MakeRecord         7    5  42                          0  r[42]=mkrec(r[7..11])
   90        NewRowid           6   39   0                          0  r[39]=rowid
-  91        Insert             6   42  39  buffer_table_window_0   2  intkey=r[39] data=r[42]
+  91        Insert             6   42  39  buffer_table_window_0   6  intkey=r[39] data=r[42]
   92        Rewind             5   94   0                          0  Rewind  ephemeral(buffer_table_window_0)
   93        Rewind             7   94   0                          0  Rewind  ephemeral(buffer_table_window_0)
   94        Goto               0  111   0                          0
   95        MakeRecord         7    5  43                          0  r[43]=mkrec(r[7..11])
   96        NewRowid           6   39   0                          0  r[39]=rowid
-  97        Insert             6   43  39  buffer_table_window_0   2  intkey=r[39] data=r[43]
+  97        Insert             6   43  39  buffer_table_window_0   6  intkey=r[39] data=r[43]
   98        Goto               0  111   0                          0  ; peer of previous row: buffer only, handle at group end
   99        Column             7    3  44                          0  r[44]=ephemeral(buffer_table_window_0).salary
  100        AggStep            0   44  32  sum                     0  accum=r[32] step(r[44])

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/windows/snapshots/windows__row-number-basic.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/windows/snapshots/windows__row-number-basic.snap
@@ -45,13 +45,13 @@ addr  opcode              p1  p2  p3  p4                     p5  comment
   20        Null           0  11  11                          0  r[11..11]=NULL; reset accumulator registers
   21        MakeRecord     2   4  21                          0  r[21]=mkrec(r[2..5])
   22        NewRowid       3  17   0                          0  r[17]=rowid
-  23        Insert         3  21  17  buffer_table_window_0   2  intkey=r[17] data=r[21]
+  23        Insert         3  21  17  buffer_table_window_0   6  intkey=r[17] data=r[21]
   24        Rewind         2  26   0                          0  Rewind  ephemeral(buffer_table_window_0)
   25        Rewind         4  26   0                          0  Rewind  ephemeral(buffer_table_window_0)
   26        Goto           0  38   0                          0
   27        MakeRecord     2   4  22                          0  r[22]=mkrec(r[2..5])
   28        NewRowid       3  17   0                          0  r[17]=rowid
-  29        Insert         3  22  17  buffer_table_window_0   2  intkey=r[17] data=r[22]
+  29        Insert         3  22  17  buffer_table_window_0   6  intkey=r[17] data=r[22]
   30        AggStep        0   0  11  row_number              0  accum=r[11] step(r[0])
   31        Next           4  32   0                          0
   32        AggValue       0  11  12  row_number              0  accum=r[11] dest=r[12]

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/windows/snapshots/windows__running-total.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/windows/snapshots/windows__running-total.snap
@@ -69,13 +69,13 @@ addr  opcode                   p1   p2   p3  p4                     p5  comment
   37            Null            0   18   18                          0  r[18..18]=NULL; reset accumulator registers
   38            MakeRecord      3    4   32                          0  r[32]=mkrec(r[3..6])
   39            NewRowid        5   24    0                          0  r[24]=rowid
-  40            Insert          5   32   24  buffer_table_window_1   2  intkey=r[24] data=r[32]
+  40            Insert          5   32   24  buffer_table_window_1   6  intkey=r[24] data=r[32]
   41            Rewind          4   43    0                          0  Rewind  ephemeral(buffer_table_window_1)
   42            Rewind          6   43    0                          0  Rewind  ephemeral(buffer_table_window_1)
   43            Goto            0   70    0                          0
   44            MakeRecord      3    4   33                          0  r[33]=mkrec(r[3..6])
   45            NewRowid        5   24    0                          0  r[24]=rowid
-  46            Insert          5   33   24  buffer_table_window_1   2  intkey=r[24] data=r[33]
+  46            Insert          5   33   24  buffer_table_window_1   6  intkey=r[24] data=r[33]
   47            Compare        27   28    1  k(1, Binary)            0  r[27..27]==r[28..28]; peer of previous row: buffer only, handle at group end
   48            Jump           49   70   49                          0
   49            Copy           27   28    0                          0  r[28]=r[27]
@@ -155,13 +155,13 @@ addr  opcode                   p1   p2   p3  p4                     p5  comment
  123        Null                0   51   51                          0  r[51..51]=NULL; reset accumulator registers
  124        MakeRecord         12    5   65                          0  r[65]=mkrec(r[12..16])
  125        NewRowid            9   58    0                          0  r[58]=rowid
- 126        Insert              9   65   58  buffer_table_window_0   2  intkey=r[58] data=r[65]
+ 126        Insert              9   65   58  buffer_table_window_0   6  intkey=r[58] data=r[65]
  127        Rewind              8  129    0                          0  Rewind  ephemeral(buffer_table_window_0)
  128        Rewind             10  129    0                          0  Rewind  ephemeral(buffer_table_window_0)
  129        Goto                0  156    0                          0
  130        MakeRecord         12    5   66                          0  r[66]=mkrec(r[12..16])
  131        NewRowid            9   58    0                          0  r[58]=rowid
- 132        Insert              9   66   58  buffer_table_window_0   2  intkey=r[58] data=r[66]
+ 132        Insert              9   66   58  buffer_table_window_0   6  intkey=r[58] data=r[66]
  133        Compare            60   61    1  k(1, Binary)            0  r[60..60]==r[61..61]; peer of previous row: buffer only, handle at group end
  134        Jump              135  156  135                          0
  135        Copy               60   61    0                          0  r[61]=r[60]

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/windows/snapshots/windows__window-order-by.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/windows/snapshots/windows__window-order-by.snap
@@ -55,13 +55,13 @@ addr  opcode              p1  p2  p3  p4                     p5  comment
   28        Null           0  19  19                          0  r[19..19]=NULL; reset accumulator registers
   29        MakeRecord     2   5  31                          0  r[31]=mkrec(r[2..6])
   30        NewRowid       4  26   0                          0  r[26]=rowid
-  31        Insert         4  31  26  buffer_table_window_0   2  intkey=r[26] data=r[31]
+  31        Insert         4  31  26  buffer_table_window_0   6  intkey=r[26] data=r[31]
   32        Rewind         3  34   0                          0  Rewind  ephemeral(buffer_table_window_0)
   33        Rewind         5  34   0                          0  Rewind  ephemeral(buffer_table_window_0)
   34        Goto           0  47   0                          0
   35        MakeRecord     2   5  32                          0  r[32]=mkrec(r[2..6])
   36        NewRowid       4  26   0                          0  r[26]=rowid
-  37        Insert         4  32  26  buffer_table_window_0   2  intkey=r[26] data=r[32]
+  37        Insert         4  32  26  buffer_table_window_0   6  intkey=r[26] data=r[32]
   38        AggStep        0   0  19  row_number              0  accum=r[19] step(r[0])
   39        Next           5  40   0                          0
   40        AggValue       0  19  20  row_number              0  accum=r[19] dest=r[20]

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/windows/snapshots/windows__window-over-grouped.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/windows/snapshots/windows__window-over-grouped.snap
@@ -83,13 +83,13 @@ addr  opcode                      p1  p2  p3  p4                     p5  comment
   57        Null                   0  25  25                          0  r[25..25]=NULL; reset accumulator registers
   58        MakeRecord             2   3  34                          0  r[34]=mkrec(r[2..4])
   59        NewRowid               5  30   0                          0  r[30]=rowid
-  60        Insert                 5  34  30  buffer_table_window_0   2  intkey=r[30] data=r[34]
+  60        Insert                 5  34  30  buffer_table_window_0   6  intkey=r[30] data=r[34]
   61        Rewind                 4  63   0                          0  Rewind  ephemeral(buffer_table_window_0)
   62        Rewind                 6  63   0                          0  Rewind  ephemeral(buffer_table_window_0)
   63        Goto                   0  75   0                          0
   64        MakeRecord             2   3  35                          0  r[35]=mkrec(r[2..4])
   65        NewRowid               5  30   0                          0  r[30]=rowid
-  66        Insert                 5  35  30  buffer_table_window_0   2  intkey=r[30] data=r[35]
+  66        Insert                 5  35  30  buffer_table_window_0   6  intkey=r[30] data=r[35]
   67        AggStep                0   0  25  row_number              0  accum=r[25] step(r[0])
   68        Next                   6  69   0                          0
   69        AggValue               0  25  26  row_number              0  accum=r[25] dest=r[26]

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/windows/snapshots/windows__window-with-subquery.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/windows/snapshots/windows__window-with-subquery.snap
@@ -66,13 +66,13 @@ addr  opcode                  p1   p2  p3  p4                     p5  comment
   28            Null           0   13  13                          0  r[13..13]=NULL; reset accumulator registers
   29            MakeRecord     4    4  23                          0  r[23]=mkrec(r[4..7])
   30            NewRowid       3   19   0                          0  r[19]=rowid
-  31            Insert         3   23  19  buffer_table_window_0   2  intkey=r[19] data=r[23]
+  31            Insert         3   23  19  buffer_table_window_0   6  intkey=r[19] data=r[23]
   32            Rewind         2   34   0                          0  Rewind  ephemeral(buffer_table_window_0)
   33            Rewind         4   34   0                          0  Rewind  ephemeral(buffer_table_window_0)
   34            Goto           0   53   0                          0
   35            MakeRecord     4    4  24                          0  r[24]=mkrec(r[4..7])
   36            NewRowid       3   19   0                          0  r[19]=rowid
-  37            Insert         3   24  19  buffer_table_window_0   2  intkey=r[19] data=r[24]
+  37            Insert         3   24  19  buffer_table_window_0   6  intkey=r[19] data=r[24]
   38            Goto           0   53   0                          0  ; peer of previous row: buffer only, handle at group end
   39            Column         4    3  25                          0  r[25]=ephemeral(buffer_table_window_0).salary
   40            AggStep        0   25  13  avg                     0  accum=r[13] step(r[25])
@@ -149,13 +149,13 @@ addr  opcode                  p1   p2  p3  p4                     p5  comment
  111        Null               0   49  49                          0  r[49..49]=NULL; reset accumulator registers
  112        MakeRecord        27    6  60                          0  r[60]=mkrec(r[27..32])
  113        NewRowid           8   56   0                          0  r[56]=rowid
- 114        Insert             8   60  56  buffer_table_window_0   2  intkey=r[56] data=r[60]
+ 114        Insert             8   60  56  buffer_table_window_0   6  intkey=r[56] data=r[60]
  115        Rewind             7  117   0                          0  Rewind  ephemeral(buffer_table_window_0)
  116        Rewind             9  117   0                          0  Rewind  ephemeral(buffer_table_window_0)
  117        Goto               0  128   0                          0
  118        MakeRecord        27    6  61                          0  r[61]=mkrec(r[27..32])
  119        NewRowid           8   56   0                          0  r[56]=rowid
- 120        Insert             8   61  56  buffer_table_window_0   2  intkey=r[56] data=r[61]
+ 120        Insert             8   61  56  buffer_table_window_0   6  intkey=r[56] data=r[61]
  121        AggStep            0    0  49  row_number              0  accum=r[49] step(r[0])
  122        Next               9  123   0                          0
  123        AggValue           0   49  50  row_number              0  accum=r[49] dest=r[50]

--- a/sqlite/conformance/sqlite-sqltests/window-preserves-last-insert-rowid.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/window-preserves-last-insert-rowid.sqltest
@@ -1,0 +1,15 @@
+@database :memory:
+
+# Window frame buffering uses an ephemeral table and must not change
+# last_insert_rowid().
+test window-preserves-last-insert-rowid {
+    CREATE TABLE t(id INTEGER PRIMARY KEY, k TEXT);
+    INSERT INTO t VALUES (1, 'a'), (2, 'b'), (3, 'c'), (4, 'd'), (5, 'e');
+    INSERT INTO t(k) VALUES ('f');
+    SELECT count(*) FROM (SELECT row_number() OVER (ORDER BY k) FROM t WHERE id < 3);
+    SELECT last_insert_rowid();
+}
+expect {
+    2
+    6
+}


### PR DESCRIPTION
Fixes #8698

Window execution buffers source rows in an internal ephemeral table. Those inserts were missing the ephemeral-table flag, so they updated the connection's last_insert_rowid() and overwrote the rowid from the user's previous INSERT.

Marking the buffer insert as ephemeral preserves SQLite behavior. A regression sqltest covers a window read followed by last_insert_rowid().

Validation: pre-fix regression returned 2 instead of 6; cargo fmt -- --check; cargo build --bin tursodb; focused sqltest passes.