### PR TITLE
fix: avoid burning AUTOINCREMENT ids on OR FAIL

### DIFF
--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -675,106 +675,8 @@ pub fn translate_insert(
     // For AUTOINCREMENT tables with an explicit rowid, update sqlite_sequence
     // before CHECK constraints. SQLite updates sqlite_sequence even when
     // INSERT OR IGNORE skips the row due to a CHECK failure.
-    if has_user_provided_rowid {
-        if is_mvcc && ctx.table.has_autoincrement {
-            // MVCC mode: advance the implicit sequence's disk watermark past
-            // the user-supplied rowid so the next auto-generated rowid is
-            // strictly greater. The helper is a no-op when the explicit
-            // rowid is already <= current watermark.
-            let seq_name = crate::schema::autoincrement_sequence_name(&ctx.table.name);
-            let seq = resolver
-                .with_schema(ctx.database_id, |s| s.get_sequence(&seq_name).cloned())
-                .ok_or_else(|| {
-                    crate::LimboError::InternalError(format!(
-                        "missing implicit sequence for AUTOINCREMENT table \"{}\"",
-                        ctx.table.name
-                    ))
-                })?;
-            crate::translate::sequence::emit_disk_advance_past(
-                program,
-                resolver,
-                ctx.database_id,
-                &seq_name,
-                &seq,
-                insertion.key_register(),
-            )?;
-        } else if let Some(AutoincMeta {
-            seq_cursor_id,
-            r_seq,
-            r_seq_rowid,
-            table_name_reg,
-        }) = ctx.autoincrement_meta
-        {
-            turso_assert!(ctx.table.has_autoincrement);
-            reload_autoincrement_state(
-                program,
-                AutoincMeta {
-                    seq_cursor_id,
-                    r_seq,
-                    r_seq_rowid,
-                    table_name_reg,
-                },
-            );
-            // Existing sqlite_sequence row: update only when explicit key advances seq.
-            let missing_row_label = program.allocate_label();
-            let explicit_done_label = program.allocate_label();
-            program.emit_insn(Insn::IsNull {
-                reg: r_seq_rowid,
-                target_pc: missing_row_label,
-            });
-
-            let skip_seq_update_label = program.allocate_label();
-            program.emit_insn(Insn::Le {
-                lhs: insertion.key_register(),
-                rhs: r_seq,
-                target_pc: skip_seq_update_label,
-                flags: Default::default(),
-                collation: None,
-            });
-
-            emit_update_sqlite_sequence(
-                program,
-                resolver,
-                ctx.database_id,
-                seq_cursor_id,
-                r_seq_rowid,
-                table_name_reg,
-                insertion.key_register(),
-            )?;
-            program.emit_insn(Insn::Goto {
-                target_pc: explicit_done_label,
-            });
-
-            // SQLite leaves sqlite_sequence unchanged when the explicit key
-            // does not advance seq.
-            program.preassign_label_to_next_insn(skip_seq_update_label);
-            program.emit_insn(Insn::Goto {
-                target_pc: explicit_done_label,
-            });
-
-            // If sqlite_sequence has no row yet, write max(0, explicit_key).
-            program.preassign_label_to_next_insn(missing_row_label);
-            let seq_to_write_reg = program.alloc_register();
-            program.emit_insn(Insn::Copy {
-                src_reg: r_seq,
-                dst_reg: seq_to_write_reg,
-                extra_amount: 0,
-            });
-            program.emit_insn(Insn::MemMax {
-                dest_reg: seq_to_write_reg,
-                src_reg: insertion.key_register(),
-            });
-            emit_update_sqlite_sequence(
-                program,
-                resolver,
-                ctx.database_id,
-                seq_cursor_id,
-                r_seq_rowid,
-                table_name_reg,
-                seq_to_write_reg,
-            )?;
-            program.preassign_label_to_next_insn(explicit_done_label);
-        }
+    if has_user_provided_rowid && !matches!(ctx.on_conflict, ResolveType::Fail) {
+        emit_explicit_autoincrement_sequence_update(program, resolver, &ctx, &insertion, is_mvcc)?;
     }
 
     // Make computed virtual columns accessible to CHECK and NOT NULL constraint evaluation
@@ -918,6 +820,13 @@ pub fn translate_insert(
             database_id,
             &fk_layout,
         )?;
+    }
+
+    // OR FAIL preserves prior statement changes but does not commit the
+    // rejected row's explicit AUTOINCREMENT value. Defer the sequence update
+    // until all row-level validation has succeeded.
+    if has_user_provided_rowid && matches!(ctx.on_conflict, ResolveType::Fail) {
+        emit_explicit_autoincrement_sequence_update(program, resolver, &ctx, &insertion, is_mvcc)?;
     }
 
     // Emit deferred index inserts for cases where preflight only checked constraints
@@ -3711,6 +3620,116 @@ fn build_constraints_to_check(
         constraints_to_check,
         upsert_catch_all_position,
     }
+}
+
+fn emit_explicit_autoincrement_sequence_update(
+    program: &mut ProgramBuilder,
+    resolver: &Resolver,
+    ctx: &InsertEmitCtx,
+    insertion: &Insertion,
+    is_mvcc: bool,
+) -> Result<()> {
+    if is_mvcc && ctx.table.has_autoincrement {
+        // MVCC mode: advance the implicit sequence's disk watermark past
+        // the user-supplied rowid so the next auto-generated rowid is
+        // strictly greater. The helper is a no-op when the explicit
+        // rowid is already <= current watermark.
+        let seq_name = crate::schema::autoincrement_sequence_name(&ctx.table.name);
+        let seq = resolver
+            .with_schema(ctx.database_id, |s| s.get_sequence(&seq_name).cloned())
+            .ok_or_else(|| {
+                crate::LimboError::InternalError(format!(
+                    "missing implicit sequence for AUTOINCREMENT table \"{}\"",
+                    ctx.table.name
+                ))
+            })?;
+        crate::translate::sequence::emit_disk_advance_past(
+            program,
+            resolver,
+            ctx.database_id,
+            &seq_name,
+            &seq,
+            insertion.key_register(),
+        )?;
+    } else if let Some(AutoincMeta {
+        seq_cursor_id,
+        r_seq,
+        r_seq_rowid,
+        table_name_reg,
+    }) = ctx.autoincrement_meta
+    {
+        turso_assert!(ctx.table.has_autoincrement);
+        reload_autoincrement_state(
+            program,
+            AutoincMeta {
+                seq_cursor_id,
+                r_seq,
+                r_seq_rowid,
+                table_name_reg,
+            },
+        );
+        // Existing sqlite_sequence row: update only when explicit key advances seq.
+        let missing_row_label = program.allocate_label();
+        let explicit_done_label = program.allocate_label();
+        program.emit_insn(Insn::IsNull {
+            reg: r_seq_rowid,
+            target_pc: missing_row_label,
+        });
+
+        let skip_seq_update_label = program.allocate_label();
+        program.emit_insn(Insn::Le {
+            lhs: insertion.key_register(),
+            rhs: r_seq,
+            target_pc: skip_seq_update_label,
+            flags: Default::default(),
+            collation: None,
+        });
+
+        emit_update_sqlite_sequence(
+            program,
+            resolver,
+            ctx.database_id,
+            seq_cursor_id,
+            r_seq_rowid,
+            table_name_reg,
+            insertion.key_register(),
+        )?;
+        program.emit_insn(Insn::Goto {
+            target_pc: explicit_done_label,
+        });
+
+        // SQLite leaves sqlite_sequence unchanged when the explicit key
+        // does not advance seq.
+        program.preassign_label_to_next_insn(skip_seq_update_label);
+        program.emit_insn(Insn::Goto {
+            target_pc: explicit_done_label,
+        });
+
+        // If sqlite_sequence has no row yet, write max(0, explicit_key).
+        program.preassign_label_to_next_insn(missing_row_label);
+        let seq_to_write_reg = program.alloc_register();
+        program.emit_insn(Insn::Copy {
+            src_reg: r_seq,
+            dst_reg: seq_to_write_reg,
+            extra_amount: 0,
+        });
+        program.emit_insn(Insn::MemMax {
+            dest_reg: seq_to_write_reg,
+            src_reg: insertion.key_register(),
+        });
+        emit_update_sqlite_sequence(
+            program,
+            resolver,
+            ctx.database_id,
+            seq_cursor_id,
+            r_seq_rowid,
+            table_name_reg,
+            seq_to_write_reg,
+        )?;
+        program.preassign_label_to_next_insn(explicit_done_label);
+    }
+
+    Ok(())
 }
 
 fn emit_update_sqlite_sequence(

--- a/core/vdbe/statement_lifecycle_tests.rs
+++ b/core/vdbe/statement_lifecycle_tests.rs
@@ -204,6 +204,52 @@ fn fail_rolls_back_base_rows_when_index_method_preparation_fails() {
     assert!(get_rows(&conn, "SELECT id FROM docs").is_empty());
 }
 
+/// INSERT OR FAIL must not advance the AUTOINCREMENT sequence when a CHECK
+/// constraint rejects the explicit row. The next successful implicit rowid
+/// must remain the first available value.
+#[test]
+fn insert_or_fail_check_does_not_advance_autoincrement_sequence() {
+    let io = Arc::new(MemoryIO::new());
+    let db = Database::open_file_with_flags(
+        io,
+        ":memory:autoincrement-fail-check",
+        OpenFlags::default(),
+        DatabaseOpts::default(),
+        None,
+        Arc::new(SqliteDialect),
+    )
+    .unwrap();
+    let conn = db.connect().unwrap();
+
+    conn.execute("CREATE TABLE t(a INTEGER PRIMARY KEY AUTOINCREMENT, b INTEGER CHECK(b > 0))")
+        .unwrap();
+    let error = conn
+        .execute("INSERT OR FAIL INTO t VALUES (7, 0)")
+        .expect_err("the CHECK constraint must reject the OR FAIL row");
+    assert!(
+        error.to_string().contains("CHECK constraint failed"),
+        "unexpected error: {error}"
+    );
+
+    conn.execute("INSERT INTO t(b) VALUES (1)").unwrap();
+    assert_eq!(scalar_i64(&conn, "SELECT a FROM t"), 1);
+    assert_eq!(
+        scalar_i64(&conn, "SELECT seq FROM sqlite_sequence WHERE name = 't'"),
+        1
+    );
+
+    conn.execute("INSERT OR FAIL INTO t VALUES (7, 2)").unwrap();
+    conn.execute("INSERT INTO t(b) VALUES (1)").unwrap();
+    assert_eq!(
+        ids_from_query(&conn, "SELECT a FROM t ORDER BY a"),
+        vec![1, 7, 8]
+    );
+    assert_eq!(
+        scalar_i64(&conn, "SELECT seq FROM sqlite_sequence WHERE name = 't'"),
+        8
+    );
+}
+
 /// Delegates to `MemoryIO` and counts every `step` / `wait_for_completion`
 /// made while the test is inside `Statement::step`: that is the engine
 /// pumping I/O synchronously instead of yielding it to the caller.


### PR DESCRIPTION
Fixes #8740

For an explicit rowid on an AUTOINCREMENT table, the INSERT translator updated sqlite_sequence before CHECK, uniqueness, and foreign-key validation. INSERT OR FAIL then left the rejected row's sequence update behind, so the next generated id was too large.

The sequence update is shared through a helper. Existing conflict modes retain their early SQLite-compatible update, while OR FAIL defers it until row validation succeeds. The regression test verifies both the rejected row followed by id 1 and a successful explicit OR FAIL row followed by id 8.

Validation: pre-fix focused unit test produced id 8 instead of 1; cargo fmt -- --check; focused turso_core test passes.