### PR TITLE
fts: borrow backing-row fields during decoding

### DIFF
--- a/core/index_method/fts/mod.rs
+++ b/core/index_method/fts/mod.rs
@@ -1554,7 +1554,7 @@ impl FtsCursor {
                         self.state = FtsState::ProbeFormat { rewound: false };
                         continue;
                     }
-                    self.control = Some(FtsControlV2::decode(&bytes)?);
+                    self.control = Some(FtsControlV2::decode(bytes)?);
                     if self.probe_only {
                         // Insert fast path: the store is v2; nothing else
                         // needs loading to append segments.
@@ -1686,7 +1686,7 @@ impl FtsCursor {
                         continue;
                     };
                     let segment_id = parse_segment_id(uuid)?;
-                    let descriptor = SegmentDescriptor::decode(segment_id, &bytes)?;
+                    let descriptor = SegmentDescriptor::decode(segment_id, bytes)?;
                     // Duplicate segment ids in one searcher trip a
                     // SearcherGeneration assert inside Tantivy; dedupe the
                     // registry scan defensively.
@@ -2857,7 +2857,8 @@ impl FtsBackingRowDumper {
             let hash = bytes.iter().fold(0xcbf2_9ce4_8422_2325u64, |hash, byte| {
                 (hash ^ u64::from(*byte)).wrapping_mul(0x100_0000_01b3)
             });
-            self.rows.push((path, chunk_no, bytes.len(), hash));
+            self.rows
+                .push((path.to_owned(), chunk_no, bytes.len(), hash));
             self.advance_pending = true;
         }
     }

--- a/core/index_method/fts/output.rs
+++ b/core/index_method/fts/output.rs
@@ -1008,7 +1008,9 @@ mod tests {
             loop {
                 match cursor.record().unwrap() {
                     IOResult::Done(record) => {
-                        rows.push(super::super::rows::row_fields(record.unwrap()).unwrap());
+                        let (path, chunk, bytes) =
+                            super::super::rows::row_fields(record.unwrap()).unwrap();
+                        rows.push((path.to_owned(), chunk, bytes.to_vec()));
                         break;
                     }
                     IOResult::IO(_) => io.step().unwrap(),

--- a/core/index_method/fts/read.rs
+++ b/core/index_method/fts/read.rs
@@ -394,12 +394,42 @@ fn chunk_bytes(
             "FTS unexpected chunk {path}:{chunk}"
         )));
     }
-    Ok(bytes)
+    Ok(bytes.to_vec())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn row_fields_borrow_record_storage_and_chunks_remain_owned() {
+        use crate::types::{ImmutableRecord, TextRef, TextSubtype, ValueRef};
+
+        let record = ImmutableRecord::from_values(
+            [
+                ValueRef::Text(TextRef::new("segment/雪", TextSubtype::Text)),
+                ValueRef::Numeric(crate::Numeric::Integer(3)),
+                ValueRef::Blob(&[9, 0, 255, 2]),
+            ],
+            3,
+        )
+        .unwrap();
+        let (path, chunk, bytes) = row_fields(&record).unwrap();
+        assert_eq!(path, "segment/雪");
+        assert_eq!(chunk, 3);
+        assert_eq!(bytes, &[9, 0, 255, 2]);
+        let ValueRef::Text(stored_path) = record.get_value_opt(0).unwrap() else {
+            panic!()
+        };
+        let ValueRef::Blob(stored_bytes) = record.get_value_opt(2).unwrap() else {
+            panic!()
+        };
+        assert_eq!(path.as_ptr(), stored_path.value.as_ptr());
+        assert_eq!(bytes.as_ptr(), stored_bytes.as_ptr());
+        let owned = chunk_bytes(&record, "segment/雪", 3).unwrap();
+        drop(record);
+        assert_eq!(owned, [9, 0, 255, 2]);
+    }
 
     #[test]
     fn range_cache_evicts_least_recently_used_row() {

--- a/core/index_method/fts/rows.rs
+++ b/core/index_method/fts/rows.rs
@@ -66,11 +66,11 @@ pub(super) fn chunk_rows(path: &str, data: &[u8], chunk_size: usize) -> Vec<Pend
 }
 
 /// Extract `(path, chunk_no, bytes)` from the cursor's current record.
-pub(super) fn row_fields(record: &ImmutableRecord) -> Result<(String, i64, Vec<u8>)> {
+pub(super) fn row_fields(record: &ImmutableRecord) -> Result<(&str, i64, &[u8])> {
     let path = record
         .get_value_opt(0)
         .and_then(|value| match value {
-            crate::types::ValueRef::Text(text) => Some(text.value.to_string()),
+            crate::types::ValueRef::Text(text) => Some(text.value),
             _ => None,
         })
         .ok_or_else(|| LimboError::Corrupt("FTS row path is not text".into()))?;
@@ -84,7 +84,7 @@ pub(super) fn row_fields(record: &ImmutableRecord) -> Result<(String, i64, Vec<u
     let bytes = record
         .get_value_opt(2)
         .and_then(|value| match value {
-            crate::types::ValueRef::Blob(blob) => Some(blob.to_vec()),
+            crate::types::ValueRef::Blob(blob) => Some(blob),
             _ => None,
         })
         .ok_or_else(|| LimboError::Corrupt("FTS row payload is not a blob".into()))?;


### PR DESCRIPTION
## Description

Borrow path/payload views from the current FTS backing record for immediate decode/inspection instead of allocating both fields. `chunk_bytes` still returns an owned Vec; collectors explicitly own data before cursor advancement. No unsafe code, format changes, caches or extra storage callbacks.

## Allocation and profile evidence

Compared against #8879 using the identical #8878 ChaCha8 `0xF75` seeded harness, existing approved `bench-profile`, Rust1.88, Debian12 x64 four-CPU orb.

Scoped DHAT probe in `run_mvcc_query`, excluding fixture/preflight, including prepare/execution/statement cleanup. This separate instrumentation uses DHAT's system allocator, not the mimalloc timing binary. The temporary dependency/allocator/Profiler changes are removed; reproduction patch and raw JSON retained.

| Query | Before allocated bytes / blocks | After allocated bytes / blocks | Scoped peak bytes before = after |
|---|---:|---:|---:|
| selective, 1k rows / 2 segments | 200,434 / 1,418 | 198,756 / 1,394 | 64,223 |
| ranked phrase, 1k / 2 segments | 228,829 / 1,467 | 227,103 / 1,442 | 74,907 |
| selective, 5k / 50 segments | 2,105,588 / 24,196 | 2,064,598 / 23,644 | 346,034 |

About1.9% fewer requested bytes and2.3% fewer allocations in the50-segment case. End-of-query retention unchanged. Scoped peak is only newly tracked query allocations, NOT the whole live engine heap/RSS or a memory cap.

Scoped mimalloc Callgrind instructions: 50-segment selective21,536,893→21,465,234 (-0.33%); two-segment selective892,316→888,781 (-0.40%). Cache/branch results are mixed. Simulated events, not hardware counters.

Four alternating14-case mimalloc timing pairs (0.5s warmup,2s measurement,30 samples; writes override to10) have median changes -9.8% to+3.3% with substantial overlapping variation. Retained for allocation reduction; no broad wall-clock gain is established. No timing from DHAT runs is used.

## Ownership and validation

Audited every `row_fields` caller: control/descriptor decode returns owned values, path/UUID/tombstone checks finish before cursor advancement, dump/test collectors copy surviving fields, extra-chunk inspection retains nothing, and `chunk_bytes` owns payload before cache insertion or suspension. No borrowed view crosses `return_if_io`, pending Completion, cursor mutation, rollback or reset.

- Pointer-identity regression fails against original owning-copy helper and passes here; owned chunk remains valid after record destruction.
- 29 FTS unit tests passed, including delayed read/error/cancellation tests.
- 117 index-method integrations passed, including production build/merge delayed output failure/abort, cleanup/rollback and backing-row visibility checks.
- 379 MVCC tests passed, 6 ignored.
- Two Whopper regression cases passed: seeds 0xF75/0xF7501/0xF7502, six connections/12,000 steps, exact replay, same-snapshot FTS oracle, fixed long snapshot/OPTIMIZE/savepoint/full rollback/recovery interleaving.
- All 72 benchmark correctness cases passed.
- Nightly CodSpeed benchmark check passed. Stable Clippy reports only the existing local JSON-cache lint expectation warning; actual head CI tracked separately.

Raw evidence: `/tmp/fts-profiles/dhat-{column,borrow}-*.{log,json}`, `dhat-probe.patch`, `row-borrow-before.log`, `row-ir-*`, `seeded-paired-borrow-*`, `final-*.log` in profiling thread.

## Description of AI Usage

Implemented, profiled and verified with Amp under user-directed optimization and reviewable-stack publication instructions.
