### PR TITLE
fix: preserve GROUP BY expressions for ORDER BY

### DIFF
--- a/core/translate/group_by.rs
+++ b/core/translate/group_by.rs
@@ -427,12 +427,22 @@ fn collect_non_aggregate_expressions<'a>(
     }
 
     for group_expr in &group_by.exprs {
+        // GROUP BY expressions that also appear in ORDER BY must be retained
+        // in the per-group accumulator.  ORDER BY is evaluated while the
+        // grouped rows are emitted, after the source table loop has finished;
+        // without the cached group value, translating an expression such as
+        // `lower(x)` reads a stale table register and all groups receive the
+        // same (or otherwise incorrect) sort key.
+        let expr_appears_in_order_by = order_by
+            .iter()
+            .any(|(order_expr, _, _)| exprs_are_equivalent(order_expr, group_expr));
         let expr_appears_in_result_columns = result_columns
             .iter()
             .any(|expr| exprs_are_equivalent(expr, group_expr))
             || root_result_columns
                 .iter()
-                .any(|rc| exprs_are_equivalent(&rc.expr, group_expr));
+                .any(|rc| exprs_are_equivalent(&rc.expr, group_expr))
+            || expr_appears_in_order_by;
         non_aggregate_expressions.push((group_expr, expr_appears_in_result_columns));
     }
     for expr in result_columns {

--- a/sqlite/conformance/turso-sqltests/group-by-order-expression.sqltest
+++ b/sqlite/conformance/turso-sqltests/group-by-order-expression.sqltest
@@ -1,0 +1,44 @@
+@database :memory:
+
+test group-by-expression-order-by-expression {
+    CREATE TABLE t(x TEXT, z INT);
+    INSERT INTO t VALUES('C',1),('A',2),('B',3);
+    SELECT min(x) FROM t GROUP BY lower(x) ORDER BY lower(x), min(z);
+}
+expect {
+    A
+    B
+    C
+}
+
+test group-by-expression-order-by-expression-desc {
+    CREATE TABLE t(x TEXT, z INT);
+    INSERT INTO t VALUES('C',1),('A',2),('B',3);
+    SELECT min(x) FROM t GROUP BY lower(x) ORDER BY lower(x) DESC, min(z);
+}
+expect {
+    C
+    B
+    A
+}
+
+test group-by-collated-expression-order-by-limit {
+    CREATE TABLE t(x TEXT, z INT);
+    INSERT INTO t VALUES('C',1),('A',2),('B',3);
+    SELECT min(x) FROM t GROUP BY x COLLATE NOCASE
+        ORDER BY x COLLATE NOCASE, min(z) LIMIT 1;
+}
+expect {
+    A
+}
+
+test group-by-expression-order-by-only-expression {
+    CREATE TABLE t(x TEXT, z INT);
+    INSERT INTO t VALUES('C',1),('A',2),('B',3);
+    SELECT min(x) FROM t GROUP BY lower(x) ORDER BY lower(x) DESC;
+}
+expect {
+    C
+    B
+    A
+}


### PR DESCRIPTION
Fixes #8761

When a GROUP BY expression also appeared in ORDER BY but was absent from the SELECT list, grouped output did not retain the expression in the accumulator. ORDER BY was evaluated after the source loop and read a stale table register, so the leading expression was effectively ignored and LIMIT could select the wrong group.

Retain grouped expressions referenced by ORDER BY so the output sorter reads the cached group key. Add regressions for ascending and descending expression order, collated keys, and LIMIT.

Validation: pre-fix reproduction returned `C A B` for both directions and `C` with LIMIT; focused SQLLogicTests pass (4); `cargo fmt --all -- --check`; `cargo check -p turso_core` (0 errors).
