### PR TITLE
fix: preserve collations in grouped aggregate replay

### DIFF
--- a/core/translate/group_by.rs
+++ b/core/translate/group_by.rs
@@ -754,12 +754,17 @@ pub fn group_by_process_single_group(
             let cache_len = t_ctx.resolver.expr_to_reg_cache.len();
             let cache_was_enabled = t_ctx.resolver.expr_to_reg_cache_enabled;
             for (i, leaf_expr) in t_ctx.agg_leaf_columns.drain(..).enumerate() {
-                t_ctx.resolver.cache_expr_reg(
+                // Preserve implicit column collations when a sorter row is
+                // replayed for aggregate arguments and FILTER expressions.
+                // The source table column is no longer translated directly at
+                // this point, so caching with `None` would make comparisons
+                // fall back to BINARY (e.g. `a='X'` on `a COLLATE NOCASE`).
+                t_ctx.resolver.cache_scalar_expr_reg(
                     std::borrow::Cow::Owned(leaf_expr),
                     leaf_regs + i,
                     false,
-                    None,
-                );
+                    &plan.table_references,
+                )?;
             }
             t_ctx.resolver.enable_expr_to_reg_cache();
 

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/tpch/snapshots/tpch__q12-shipping-modes.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/tpch/snapshots/tpch__q12-shipping-modes.snap
@@ -85,12 +85,12 @@ addr  opcode                  p1  p2  p3  p4                                    
   38            Copy          32  37   0                                          0  r[37]=r[32]
   39            String8        0  38   0  1-URGENT                                0  r[38]='1-URGENT'
   40            Integer        1  35   0                                          0  r[35]=1
-  41            Eq            37  38  43                                          0  if r[37]==r[38] goto 43
+  41            Eq            37  38  43  Binary                                  0  if r[37]==r[38] goto 43
   42            ZeroOrNull    37  35  38                                          0  ((r[37]=NULL)|(r[38]=NULL)) ? r[35]=NULL : r[35]=0
   43            Copy          32  39   0                                          0  r[39]=r[32]
   44            String8        0  40   0  2-HIGH                                  0  r[40]='2-HIGH'
   45            Integer        1  36   0                                          0  r[36]=1
-  46            Eq            39  40  48                                          0  if r[39]==r[40] goto 48
+  46            Eq            39  40  48  Binary                                  0  if r[39]==r[40] goto 48
   47            ZeroOrNull    39  36  40                                          0  ((r[39]=NULL)|(r[40]=NULL)) ? r[36]=NULL : r[36]=0
   48            Or            36  35  34                                          0  r[34]=(r[35] || r[36])
   49            IfNot         34  52   1                                          0  if !r[34] goto 52
@@ -101,12 +101,12 @@ addr  opcode                  p1  p2  p3  p4                                    
   54            Copy          32  45   0                                          0  r[45]=r[32]
   55            String8        0  46   0  1-URGENT                                0  r[46]='1-URGENT'
   56            Integer        1  43   0                                          0  r[43]=1
-  57            Ne            45  46  59                                          0  if r[45]!=r[46] goto 59
+  57            Ne            45  46  59  Binary                                  0  if r[45]!=r[46] goto 59
   58            ZeroOrNull    45  43  46                                          0  ((r[45]=NULL)|(r[46]=NULL)) ? r[43]=NULL : r[43]=0
   59            Copy          32  47   0                                          0  r[47]=r[32]
   60            String8        0  48   0  2-HIGH                                  0  r[48]='2-HIGH'
   61            Integer        1  44   0                                          0  r[44]=1
-  62            Ne            47  48  64                                          0  if r[47]!=r[48] goto 64
+  62            Ne            47  48  64  Binary                                  0  if r[47]!=r[48] goto 64
   63            ZeroOrNull    47  44  48                                          0  ((r[47]=NULL)|(r[48]=NULL)) ? r[44]=NULL : r[44]=0
   64            And           44  43  42                                          0  r[42]=(r[43] && r[44])
   65            IfNot         42  68   1                                          0  if !r[42] goto 68

--- a/sqlite/conformance/turso-sqltests/group-by-aggregate-collation.sqltest
+++ b/sqlite/conformance/turso-sqltests/group-by-aggregate-collation.sqltest
@@ -1,0 +1,40 @@
+@database :memory:
+
+test aggregate-argument-keeps-column-collation {
+    CREATE TABLE t(g INT, a TEXT COLLATE NOCASE);
+    INSERT INTO t VALUES(1,'x'),(1,'X');
+    SELECT g, sum(a='X') FROM t GROUP BY g;
+}
+expect {
+    1|2
+}
+
+test aggregate-filter-keeps-column-collation {
+    CREATE TABLE t(g INT, a TEXT COLLATE NOCASE);
+    CREATE TABLE u(g INT PRIMARY KEY, n INT);
+    INSERT INTO t VALUES(1,'x'),(1,'X');
+    INSERT INTO u SELECT g, count(*) FILTER (WHERE a='X') FROM t GROUP BY g;
+    SELECT n FROM u;
+}
+expect {
+    2
+}
+
+test partial-index-keeps-group-sort-collation {
+    CREATE TABLE t(g INT, a TEXT COLLATE NOCASE);
+    INSERT INTO t VALUES(1,'x'),(1,'X');
+    CREATE INDEX ix ON t(g) WHERE g>0;
+    SELECT g, sum(a='X') FROM t GROUP BY g;
+}
+expect {
+    1|2
+}
+
+test literal-left-comparison-keeps-collation {
+    CREATE TABLE t(g INT, a TEXT COLLATE NOCASE);
+    INSERT INTO t VALUES(1,'x'),(1,'X');
+    SELECT g, sum('X'=a) FROM t GROUP BY g;
+}
+expect {
+    1|2
+}

--- a/sqlite/conformance/turso-sqltests/group-by-aggregate-collation.sqltest
+++ b/sqlite/conformance/turso-sqltests/group-by-aggregate-collation.sqltest
@@ -38,3 +38,14 @@ test literal-left-comparison-keeps-collation {
 expect {
     1|2
 }
+
+test aggregate-collation-survives-multiple-groups-and-partial-index {
+    CREATE TABLE t(g INT, a TEXT COLLATE NOCASE);
+    INSERT INTO t VALUES(1,'a'),(1,'A'),(2,'a');
+    CREATE INDEX tp ON t(g) WHERE g>0;
+    SELECT g, sum(a='A') FROM t GROUP BY g ORDER BY g;
+}
+expect {
+    1|2
+    2|1
+}


### PR DESCRIPTION
Fixes #8760 and #8745

GROUP BY sorter replay cached aggregate leaf columns with no collation metadata. When an aggregate argument or FILTER compared a replayed column to a literal, a declared collation such as `TEXT COLLATE NOCASE` was lost and the comparison fell back to BINARY, producing incorrect counts.

Cache sorter leaf columns with the same implicit or explicit collation context as direct expression translation. Add regressions for aggregate arguments, FILTER predicates, partial-index sorter plans, multiple groups, and the literal-left comparison form.

Validation: pre-fix reproduction returned `1` instead of `2`; focused SQLLogicTests pass (5); `cargo fmt --all -- --check`; `cargo check -p turso_core` (0 errors).
