### PR TITLE
core/translate: honor INSERT target aliases in UPSERT

### DIFF
--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -1175,6 +1175,7 @@ pub fn translate_insert(
             &mut result_columns,
             connection,
             &mut table_references,
+            tbl_name.alias.as_ref().map(|alias| alias.as_str()),
         )?;
     }
 
@@ -1588,6 +1589,7 @@ fn resolve_upserts(
     result_columns: &mut [ResultSetColumn],
     connection: &Arc<crate::Connection>,
     table_references: &mut TableReferences,
+    table_alias: Option<&str>,
 ) -> Result<()> {
     for (_, label, upsert) in upsert_actions {
         program.preassign_label_to_next_insn(*label);
@@ -1611,6 +1613,7 @@ fn resolve_upserts(
                 result_columns,
                 connection,
                 table_references,
+                table_alias,
             )?;
         } else {
             // UpsertDo::Nothing case

--- a/core/translate/upsert.rs
+++ b/core/translate/upsert.rs
@@ -485,6 +485,7 @@ pub fn emit_upsert(
     returning: &mut [ResultSetColumn],
     connection: &Arc<Connection>,
     table_references: &mut TableReferences,
+    table_alias: Option<&str>,
 ) -> crate::Result<()> {
     // Seek & snapshot CURRENT
     program.emit_insn(Insn::SeekRowid {
@@ -639,6 +640,7 @@ pub fn emit_upsert(
             expr_current_start,
             ctx.conflict_rowid_reg,
             Some(table.get_name()),
+            table_alias,
             Some(insertion),
             true,
             excluded_decoded_start,
@@ -662,6 +664,7 @@ pub fn emit_upsert(
             expr_current_start,
             ctx.conflict_rowid_reg,
             Some(table.get_name()),
+            table_alias,
             Some(insertion),
             true,
             excluded_decoded_start,
@@ -1657,6 +1660,7 @@ fn rewrite_expr_to_registers(
     base_start: usize,
     rowid_reg: usize,
     table_name: Option<&str>,
+    table_alias: Option<&str>,
     insertion: Option<&Insertion>,
     allow_excluded: bool,
     excluded_decoded_start: Option<usize>,
@@ -1685,8 +1689,20 @@ fn rewrite_expr_to_registers(
                 Expr::Qualified(ns, c) | Expr::DoublyQualified(_, ns, c) => {
                     let ns = normalize_ident(ns.as_str());
                     let c = normalize_ident(c.as_str());
+                    // An INSERT target alias replaces the base table name in
+                    // the DO UPDATE scope.  It also shadows the special
+                    // `excluded` pseudo-table when the alias is literally
+                    // named `excluded` (SQLite's name-resolution rule).
+                    let is_target_namespace = if let Some(alias) = table_alias {
+                        ns.eq_ignore_ascii_case(alias)
+                    } else {
+                        table_name_norm
+                            .as_ref()
+                            .is_some_and(|tn| ns.eq_ignore_ascii_case(tn))
+                    };
                     // Handle EXCLUDED.* if enabled
-                    if allow_excluded && ns.eq_ignore_ascii_case("excluded") {
+                    if allow_excluded && ns.eq_ignore_ascii_case("excluded") && !is_target_namespace
+                    {
                         if let Some(ins) = insertion {
                             if ROWID_STRS.iter().any(|s| s.eq_ignore_ascii_case(&c)) {
                                 *expr = Expr::Register(ins.key_register());
@@ -1711,15 +1727,13 @@ fn rewrite_expr_to_registers(
                     }
 
                     // Match the target table namespace if provided
-                    if let Some(ref tn) = table_name_norm {
-                        if ns.eq_ignore_ascii_case(tn) {
-                            if let Some(r) = col_reg_from_row_image(&c) {
-                                *expr = Expr::Register(r);
-                            } else {
-                                bail_parse_error!("no such column: {}.{}", ns, c);
-                            }
-                            return Ok(WalkControl::Continue);
+                    if is_target_namespace {
+                        if let Some(r) = col_reg_from_row_image(&c) {
+                            *expr = Expr::Register(r);
+                        } else {
+                            bail_parse_error!("no such column: {}.{}", ns, c);
                         }
+                        return Ok(WalkControl::Continue);
                     }
 
                     // In UPSERT DO UPDATE context (allow_excluded=true), a qualified

--- a/sqlite/conformance/turso-sqltests/upsert-target-alias.sqltest
+++ b/sqlite/conformance/turso-sqltests/upsert-target-alias.sqltest
@@ -1,0 +1,43 @@
+@database :memory:
+
+test upsert-target-alias-shadows-excluded {
+    CREATE TABLE t(k INT PRIMARY KEY, n INT);
+    INSERT INTO t VALUES(1,10);
+    INSERT INTO t AS excluded VALUES(1,99)
+        ON CONFLICT(k) DO UPDATE SET n = excluded.n;
+    SELECT n FROM t;
+}
+expect {
+    10
+}
+
+test upsert-target-alias-is-only-target-name {
+    CREATE TABLE t(k INT PRIMARY KEY, n INT);
+    INSERT INTO t VALUES(1,10);
+    INSERT INTO t AS x VALUES(1,7)
+        ON CONFLICT(k) DO UPDATE SET n = x.n + 1;
+    SELECT n FROM t;
+}
+expect {
+    11
+}
+
+test upsert-base-name-is-out-of-scope-when-aliased {
+    CREATE TABLE t(k INT PRIMARY KEY, n INT);
+    INSERT INTO t VALUES(1,10);
+    INSERT INTO t AS x VALUES(1,7)
+        ON CONFLICT(k) DO UPDATE SET n = t.n + 1;
+}
+expect error {
+    no such column
+}
+
+test plain-update-target-alias-still-works {
+    CREATE TABLE t(k INT PRIMARY KEY, n INT);
+    INSERT INTO t VALUES(1,10);
+    UPDATE t AS x SET n = x.n + 1;
+    SELECT n FROM t;
+}
+expect {
+    11
+}

--- a/sqlite/conformance/upstream/all.test
+++ b/sqlite/conformance/upstream/all.test
@@ -755,7 +755,7 @@ set test_files {
   upfrom4              fail
   upsert1              fail
   upsert2              fail
-  upsert3              fail
+  upsert3              pass
   upsert4              fail
   upsert5              fail
   uri                  fail


### PR DESCRIPTION
Fixes #8757

An INSERT target alias was ignored while binding `ON CONFLICT DO UPDATE` expressions. As a result, `INSERT INTO t AS x ... DO UPDATE SET n=x.n+1` failed, the base table name remained incorrectly visible, and an alias named `excluded` could not shadow the pseudo-table.

Carry the target alias into UPSERT expression rewriting. The alias now names the target row, the base table name is out of scope when an alias is present, and an alias named `excluded` takes precedence over the pseudo-row, matching SQLite name resolution.

Validation: pre-fix focused SQLLogicTests had 3 failures; fixed suite passes (4); `cargo fmt --all -- --check`; `cargo check -p turso_core` (0 errors).
