### PR TITLE
core: preserve compound affinity from typed arms

### DIFF
--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -48,6 +48,17 @@ fn infer_type_from_expr(expr: &ast::Expr, tables: Option<&TableReferences>) -> A
     get_expr_affinity(expr, tables, None)
 }
 
+fn is_column_affinity_expr(expr: &ast::Expr) -> bool {
+    match expr {
+        ast::Expr::Column { .. } | ast::Expr::RowId { .. } => true,
+        ast::Expr::Parenthesized(exprs) if exprs.len() == 1 => {
+            is_column_affinity_expr(exprs.first().unwrap())
+        }
+        ast::Expr::Collate(expr, _) => is_column_affinity_expr(expr),
+        _ => false,
+    }
+}
+
 /// Computes the affinity of column `i` of a compound (UNION/INTERSECT/EXCEPT)
 /// subquery, matching SQLite's `sqlite3SubqueryColumnTypes` (select.c).
 ///
@@ -57,7 +68,8 @@ fn infer_type_from_expr(expr: &ast::Expr, tables: Option<&TableReferences>) -> A
 /// keeps that affinity unless a later arm yields a conflicting datatype class
 /// (TEXT affinity + a numeric arm, or numeric affinity + a text arm), in which
 /// case it is downgraded to BLOB (none) so the column is compared by storage
-/// class.
+/// class. A numeric column arm does not weaken a leading TEXT affinity: the
+/// arm's values are read through that affinity when the compound is filtered.
 pub(super) fn compound_column_affinity(arms: &[&SelectPlan], i: usize) -> Affinity {
     if arms.is_empty() {
         return Affinity::None;
@@ -74,6 +86,12 @@ pub(super) fn compound_column_affinity(arms: &[&SelectPlan], i: usize) -> Affini
             .map(|rc| expr_data_type(&rc.expr, Some(&arm.table_references)))
             .unwrap_or(StorageClassMask::from_null())
     };
+    let is_column_affinity = |arm: &SelectPlan| {
+        let Some(expr) = arm.result_columns.get(i).map(|rc| &rc.expr) else {
+            return false;
+        };
+        is_column_affinity_expr(expr)
+    };
 
     let mut affinity = col_affinities(arms[0]);
     let mut data_types = StorageClassMask::from_null();
@@ -87,9 +105,15 @@ pub(super) fn compound_column_affinity(arms: &[&SelectPlan], i: usize) -> Affini
     if affinity == Affinity::None {
         return Affinity::None;
     }
-    // This arm has a real affinity; accumulate the remaining arms' classes.
+    // A numeric column arm is coerced to a leading TEXT affinity when it is
+    // read. Do not treat its storage class as a conflict in that case; this
+    // preserves the arm-specific comparison behavior used by SQLite for a
+    // compound filtered through a TEXT column.
     for &arm in &arms[idx + 1..] {
-        data_types |= col_data_type(arm);
+        let numeric_column_arm = is_column_affinity(arm) && col_affinities(arm).is_numeric();
+        if !(affinity == Affinity::Text && numeric_column_arm) {
+            data_types |= col_data_type(arm);
+        }
     }
     match affinity {
         Affinity::Text if data_types.has_numeric() => Affinity::Blob,

--- a/sqlite/conformance/sqlite-sqltests/affinity.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/affinity.sqltest
@@ -782,3 +782,39 @@ test affinity-sum-of-text-i64-min {
 expect {
     integer|-9223372036854775808
 }
+
+# Regression test for https://github.com/tursodatabase/turso/issues/8756.
+# A typed column in a later compound arm is read through the compound's
+# leftmost affinity. Treating that arm's storage class as a conflict drops the
+# TEXT affinity and makes every TEXT row greater than an integer literal.
+@cross-check-integrity
+test affinity-compound-text-column-plus-integer-column {
+    CREATE TABLE t8756(x TEXT);
+    CREATE TABLE u8756(x TEXT);
+    CREATE TABLE v8756(y INTEGER);
+    INSERT INTO t8756 VALUES('1'),('2');
+    INSERT INTO u8756 VALUES('1'),('2');
+    INSERT INTO v8756 VALUES(9);
+
+    SELECT group_concat(x) FROM (
+        SELECT x FROM t8756 UNION ALL SELECT y FROM v8756
+    ) WHERE x > 7;
+
+    DELETE FROM u8756 WHERE x IN (
+        SELECT x FROM (
+            SELECT x FROM t8756 UNION ALL SELECT y FROM v8756
+        ) WHERE x > 7
+    );
+    SELECT count(*) FROM u8756;
+
+    SELECT group_concat(x) FROM (
+        SELECT x FROM t8756 UNION ALL SELECT 'a'
+    ) WHERE x > 7;
+    SELECT count(*) FROM t8756 WHERE x > 7;
+}
+expect {
+    9
+    2
+    a
+    0
+}


### PR DESCRIPTION
Fixes #8756.

When a compound SELECT combined a TEXT column with a later INTEGER column, the planner treated the later column's storage class as a conflicting type and discarded the compound column's TEXT affinity. Comparisons such as `x > 7` then used storage-class ordering and selected every text row.

Preserve the compound's affinity when a later arm is a typed column or rowid. No-affinity expressions such as numeric or text literals still participate in the existing conflict rule. Add a regression covering the reported SELECT and DELETE cases.

Validation:

- `cargo fmt --all -- --check`
- `cargo check -p turso_core`
- `target/debug/sqltest.exe run sqlite/conformance/sqlite-sqltests/affinity.sqltest --jobs 1`
