### PR TITLE
fix: preserve left join rows across offset

### DIFF
--- a/core/translate/emitter/mod.rs
+++ b/core/translate/emitter/mod.rs
@@ -959,6 +959,10 @@ pub(crate) struct HashLabels {
     pub inner_loop_skip: Option<BranchOffset>,
     /// Label for the grace loop's own HashNext (resolved during grace loop emission).
     pub grace_hash_next: Option<BranchOffset>,
+    /// Label for advancing the global unmatched-build-row scan.
+    pub unmatched_next: Option<BranchOffset>,
+    /// Label for advancing the grace unmatched-build-row scan.
+    pub grace_unmatched_next: Option<BranchOffset>,
 }
 
 impl HashLabels {
@@ -970,6 +974,8 @@ impl HashLabels {
             inner_loop_gosub: None,
             inner_loop_skip: None,
             grace_hash_next: None,
+            unmatched_next: None,
+            grace_unmatched_next: None,
         }
     }
 }
@@ -1002,6 +1008,9 @@ pub struct HashCtx {
     /// Register: 0 during main probe loop, 1 during grace loop.
     /// Used by IfPos dispatch before HashNext to route to the grace loop's HashNext.
     pub grace_flag_reg: Option<usize>,
+    /// Register set while the shared result body is emitting an unmatched
+    /// build-side row. This selects the correct OFFSET continuation.
+    pub unmatched_flag_reg: Option<usize>,
 }
 
 /// The TranslateCtx struct holds various information and labels used during bytecode generation.

--- a/core/translate/main_loop/body.rs
+++ b/core/translate/main_loop/body.rs
@@ -417,19 +417,62 @@ fn emit_loop_source<'a>(
                 plan.aggregates.is_empty(),
                 "QueryResult target should not have aggregates"
             );
-            let offset_jump_to = plan
-                .join_order
-                .first()
-                .and_then(|j| t_ctx.labels_main_loop.get(j.original_idx))
-                .map(|l| l.next)
+            // A hash join has another result-producing loop nested inside its
+            // probe row: `HashNext` advances to the next build-side match.
+            // OFFSET must continue there before advancing the probe cursor, or
+            // the skipped match can be emitted later as an unmatched outer row.
+            let hash_offset_paths = t_ctx.reg_offset.and_then(|_| {
+                plan.join_order.iter().rev().find_map(|join| {
+                    let table = plan
+                        .table_references
+                        .joined_tables()
+                        .get(join.original_idx)?;
+                    let Operation::HashJoin(hash_join) = &table.op else {
+                        return None;
+                    };
+                    t_ctx
+                        .hash_table_contexts
+                        .get(&hash_join.build_table_idx)
+                        .map(|ctx| {
+                            (
+                                ctx.labels.next,
+                                ctx.labels.unmatched_next,
+                                ctx.labels.grace_unmatched_next,
+                                ctx.unmatched_flag_reg,
+                                ctx.grace_flag_reg,
+                            )
+                        })
+                })
+            });
+            let offset_jump_to = hash_offset_paths
+                .map(|paths| paths.0)
+                .or_else(|| {
+                    plan.join_order
+                        .first()
+                        .and_then(|j| t_ctx.labels_main_loop.get(j.original_idx))
+                        .map(|l| l.next)
+                })
                 .or(t_ctx.label_main_loop_end);
 
-            emit_select_result(
+            let (
+                unmatched_offset_jump_to,
+                unmatched_grace_offset_jump_to,
+                reg_unmatched_flag,
+                reg_grace_flag,
+            ) = hash_offset_paths
+                .map(|paths| (paths.1, paths.2, paths.3, paths.4))
+                .unwrap_or((None, None, None, None));
+
+            emit_select_result_with_offset_paths(
                 program,
                 &t_ctx.resolver,
                 plan,
                 t_ctx.label_main_loop_end,
                 offset_jump_to,
+                unmatched_offset_jump_to,
+                unmatched_grace_offset_jump_to,
+                reg_unmatched_flag,
+                reg_grace_flag,
                 t_ctx.reg_nonagg_emit_once_flag,
                 t_ctx.reg_offset,
                 t_ctx.reg_result_cols_start.unwrap(),
@@ -562,6 +605,16 @@ pub(super) fn emit_unmatched_row_conditions_and_loop<'a>(
             &t_ctx.resolver,
         )?;
         program.preassign_label_to_next_insn(jump_target_when_true);
+    }
+
+    if let Some(unmatched_flag_reg) = t_ctx
+        .hash_table_contexts
+        .get(&build_table_idx)
+        .and_then(|ctx| ctx.unmatched_flag_reg)
+    {
+        // The result body is shared with matched hash rows. Mark this entry
+        // so its OFFSET check can use the unmatched scanner's continuation.
+        program.emit_int(1, unmatched_flag_reg);
     }
 
     if let Some((reg, label)) = gosub {

--- a/core/translate/main_loop/hash.rs
+++ b/core/translate/main_loop/hash.rs
@@ -796,9 +796,25 @@ impl<'a, 'plan> HashProbeSetupEmitter<'a, 'plan> {
         let payload_columns = payload_info.payload_columns.clone();
 
         let mut labels = HashLabels::new(match_found_label, hash_next_label);
+        let is_outer_join = matches!(
+            self.hash_join_op.join_type,
+            HashJoinType::LeftOuter | HashJoinType::FullOuter
+        );
         if self.hash_join_op.join_type == HashJoinType::FullOuter {
             labels.check_outer = Some(hash_probe_miss_label);
         };
+        if is_outer_join {
+            // These labels are allocated before the shared result body is
+            // emitted. The unmatched scanners resolve them later, after that
+            // body has been emitted.
+            labels.unmatched_next = Some(self.program.allocate_label());
+            labels.grace_unmatched_next = Some(self.program.allocate_label());
+        }
+        // The flag is only needed when OFFSET can dispatch the shared result
+        // body back into one of the unmatched-row scanners. Avoid allocating a
+        // register for ordinary outer joins so their bytecode remains stable.
+        let unmatched_flag_reg = (is_outer_join && self.t_ctx.reg_offset.is_some())
+            .then(|| self.program.alloc_register());
         self.t_ctx.hash_table_contexts.insert(
             self.hash_join_op.build_table_idx,
             HashCtx {
@@ -818,6 +834,7 @@ impl<'a, 'plan> HashProbeSetupEmitter<'a, 'plan> {
                 key_start_reg,
                 num_keys,
                 grace_flag_reg,
+                unmatched_flag_reg,
             },
         );
 
@@ -1147,7 +1164,10 @@ pub(super) fn emit_hash_join_unmatched_build_rows<'a>(
     });
 
     let unmatched_loop = program.allocate_label();
-    let label_next_unmatched = program.allocate_label();
+    let label_next_unmatched = hash_ctx
+        .labels
+        .unmatched_next
+        .expect("outer hash join must have an unmatched-row continuation label");
     program.preassign_label_to_next_insn(unmatched_loop);
 
     if let Some(cursor_id) = build_cursor_id {
@@ -1393,7 +1413,10 @@ impl GraceHashLoop {
             if let Some(plan) = select_plan {
                 let done_grace_unmatched = program.allocate_label();
                 let grace_unmatched_loop = program.allocate_label();
-                let grace_next_unmatched = program.allocate_label();
+                let grace_next_unmatched = hash_ctx
+                    .labels
+                    .grace_unmatched_next
+                    .expect("outer hash join must have a grace unmatched-row continuation label");
 
                 // Set probe cursor to NULL row (unmatched build rows have no probe match)
                 program.emit_insn(Insn::NullRow {

--- a/core/translate/main_loop/mod.rs
+++ b/core/translate/main_loop/mod.rs
@@ -31,7 +31,7 @@ use crate::{
         },
         emitter::{prepare_cdc_if_necessary, HashCtx},
         planner::{table_mask_from_expr, TableMask},
-        result_row::emit_select_result,
+        result_row::emit_select_result_with_offset_paths,
     },
     turso_assert, turso_assert_eq,
     types::SeekOp,

--- a/core/translate/main_loop/open.rs
+++ b/core/translate/main_loop/open.rs
@@ -662,6 +662,16 @@ impl OpenLoop {
                     let gosub_label = program.allocate_label();
                     let skip_label = program.allocate_label();
 
+                    if let Some(unmatched_flag_reg) = t_ctx
+                        .hash_table_contexts
+                        .get(&hj.build_table_idx)
+                        .and_then(|ctx| ctx.unmatched_flag_reg)
+                    {
+                        // The shared body is entered from both matched probe
+                        // rows and unmatched-build-row scans. Mark this entry
+                        // as the matched path before calling it.
+                        program.emit_int(0, unmatched_flag_reg);
+                    }
                     program.emit_insn(Insn::Gosub {
                         target_pc: gosub_label,
                         return_reg,

--- a/core/translate/result_row.rs
+++ b/core/translate/result_row.rs
@@ -35,11 +35,56 @@ pub fn emit_select_result(
     reg_result_cols_start: usize,
     limit_ctx: Option<LimitCtx>,
 ) -> Result<()> {
+    emit_select_result_with_offset_paths(
+        program,
+        resolver,
+        plan,
+        label_on_limit_reached,
+        offset_jump_to,
+        None,
+        None,
+        None,
+        None,
+        reg_nonagg_emit_once_flag,
+        reg_offset,
+        reg_result_cols_start,
+        limit_ctx,
+    )
+}
+
+/// Like [`emit_select_result`], but allows an outer hash join's shared result
+/// body to use a separate OFFSET continuation while scanning NULL-extended
+/// build rows. The shared body is entered both for matched hash rows and for
+/// unmatched rows, so a single static continuation would send one of those
+/// paths into the other path's iterator.
+#[allow(clippy::too_many_arguments)]
+pub fn emit_select_result_with_offset_paths(
+    program: &mut ProgramBuilder,
+    resolver: &Resolver,
+    plan: &SelectPlan,
+    label_on_limit_reached: Option<BranchOffset>,
+    offset_jump_to: Option<BranchOffset>,
+    unmatched_offset_jump_to: Option<BranchOffset>,
+    unmatched_grace_offset_jump_to: Option<BranchOffset>,
+    reg_unmatched_flag: Option<usize>,
+    reg_grace_flag: Option<usize>,
+    reg_nonagg_emit_once_flag: Option<usize>,
+    reg_offset: Option<usize>,
+    reg_result_cols_start: usize,
+    limit_ctx: Option<LimitCtx>,
+) -> Result<()> {
     let has_distinct = matches!(plan.distinctness, Distinctness::Distinct { .. });
     if !has_distinct {
-        if let (Some(jump_to), Some(_)) = (offset_jump_to, label_on_limit_reached) {
-            emit_offset(program, jump_to, reg_offset);
-        }
+        emit_offset_paths(
+            program,
+            offset_jump_to,
+            unmatched_offset_jump_to,
+            unmatched_grace_offset_jump_to,
+            reg_unmatched_flag,
+            reg_grace_flag,
+            label_on_limit_reached,
+            reg_offset,
+        );
     }
 
     let start_reg = reg_result_cols_start;
@@ -137,13 +182,93 @@ pub fn emit_select_result(
     }
 
     if has_distinct {
-        if let (Some(jump_to), Some(_)) = (offset_jump_to, label_on_limit_reached) {
-            emit_offset(program, jump_to, reg_offset);
-        }
+        emit_offset_paths(
+            program,
+            offset_jump_to,
+            unmatched_offset_jump_to,
+            unmatched_grace_offset_jump_to,
+            reg_unmatched_flag,
+            reg_grace_flag,
+            label_on_limit_reached,
+            reg_offset,
+        );
     }
 
     emit_result_row_and_limit(program, plan, start_reg, limit_ctx, label_on_limit_reached)?;
     Ok(())
+}
+
+/// Emit OFFSET handling for the normal result path and the two outer-hash
+/// unmatched paths. The branch around the unmatched block keeps matched rows
+/// from falling through into its continuation dispatch when OFFSET is zero.
+#[allow(clippy::too_many_arguments)]
+fn emit_offset_paths(
+    program: &mut ProgramBuilder,
+    offset_jump_to: Option<BranchOffset>,
+    unmatched_offset_jump_to: Option<BranchOffset>,
+    unmatched_grace_offset_jump_to: Option<BranchOffset>,
+    reg_unmatched_flag: Option<usize>,
+    reg_grace_flag: Option<usize>,
+    label_on_limit_reached: Option<BranchOffset>,
+    reg_offset: Option<usize>,
+) {
+    if label_on_limit_reached.is_none() {
+        return;
+    }
+
+    let Some(unmatched_jump_to) = unmatched_offset_jump_to else {
+        if let Some(jump_to) = offset_jump_to {
+            emit_offset(program, jump_to, reg_offset);
+        }
+        return;
+    };
+
+    let Some(unmatched_flag) = reg_unmatched_flag else {
+        if let Some(jump_to) = offset_jump_to {
+            emit_offset(program, jump_to, reg_offset);
+        }
+        return;
+    };
+
+    let unmatched_check = program.allocate_label();
+    let result_entry = program.allocate_label();
+    let unmatched_dispatch = program.allocate_label();
+
+    // Matched hash rows and ordinary nested-loop rows take the fall-through
+    // path. Unmatched rows branch to their own OFFSET check.
+    program.emit_insn(Insn::IfPos {
+        reg: unmatched_flag,
+        target_pc: unmatched_check,
+        decrement_by: 0,
+    });
+    if let Some(jump_to) = offset_jump_to {
+        emit_offset(program, jump_to, reg_offset);
+    }
+    program.emit_insn(Insn::Goto {
+        target_pc: result_entry,
+    });
+
+    program.preassign_label_to_next_insn(unmatched_check);
+    emit_offset(program, unmatched_dispatch, reg_offset);
+    program.emit_insn(Insn::Goto {
+        target_pc: result_entry,
+    });
+
+    program.preassign_label_to_next_insn(unmatched_dispatch);
+    if let (Some(grace_jump_to), Some(grace_flag)) =
+        (unmatched_grace_offset_jump_to, reg_grace_flag)
+    {
+        program.emit_insn(Insn::IfPos {
+            reg: grace_flag,
+            target_pc: grace_jump_to,
+            decrement_by: 0,
+        });
+    }
+    program.emit_insn(Insn::Goto {
+        target_pc: unmatched_jump_to,
+    });
+
+    program.preassign_label_to_next_insn(result_entry);
 }
 
 /// Emits bytecode to send column values to a destination.

--- a/sqlite/conformance/turso-sqltests/join-limit-offset.sqltest
+++ b/sqlite/conformance/turso-sqltests/join-limit-offset.sqltest
@@ -68,3 +68,46 @@ expect {
     2|2
     3|
 }
+
+test left-join-limit-offset-keeps-matched-right-row {
+    CREATE TABLE t(id INTEGER PRIMARY KEY, g TEXT);
+    CREATE TABLE u(g TEXT, k INTEGER);
+    CREATE TABLE v(id INTEGER, k INTEGER);
+    INSERT INTO t VALUES(1,'a'),(2,'a');
+    INSERT INTO u VALUES('a',5);
+    SELECT t.id, quote(u.k) FROM t LEFT JOIN u ON u.g=t.g LIMIT 10 OFFSET 1;
+    SELECT count(*), quote(sum(k)) FROM (SELECT u.k AS k FROM t LEFT JOIN u ON u.g=t.g LIMIT 10 OFFSET 1);
+    INSERT INTO v SELECT t.id, u.k FROM t LEFT JOIN u ON u.g=t.g LIMIT 10 OFFSET 1;
+    SELECT quote(k) FROM v;
+    SELECT count(*) FROM (SELECT t.id FROM t LEFT JOIN u ON u.g=t.g LIMIT 10 OFFSET 5);
+    SELECT t.id, quote(u.k) FROM t LEFT JOIN u ON u.g=t.g ORDER BY t.id LIMIT 10 OFFSET 1;
+    CREATE INDEX i ON u(g);
+    SELECT t.id, quote(u.k) FROM t LEFT JOIN u ON u.g=t.g LIMIT 10 OFFSET 1;
+}
+expect {
+    2|5
+    1|5
+    5
+    0
+    2|5
+    2|5
+}
+
+test left-join-limit-offset-unmatched-pages {
+    CREATE TABLE t(id INTEGER PRIMARY KEY, g TEXT);
+    CREATE TABLE u(g TEXT, k INTEGER);
+    INSERT INTO t VALUES(1,'a'),(2,'b'),(3,'c');
+    INSERT INTO u VALUES('a',5);
+    SELECT t.id, quote(u.k) FROM t LEFT JOIN u ON u.g=t.g LIMIT 10 OFFSET 0;
+    SELECT t.id, quote(u.k) FROM t LEFT JOIN u ON u.g=t.g LIMIT 10 OFFSET 1;
+    SELECT t.id, quote(u.k) FROM t LEFT JOIN u ON u.g=t.g LIMIT 10 OFFSET 2;
+    SELECT t.id, quote(u.k) FROM t LEFT JOIN u ON u.g=t.g LIMIT 10 OFFSET 3;
+}
+expect {
+    1|5
+    2|NULL
+    3|NULL
+    2|NULL
+    3|NULL
+    3|NULL
+}


### PR DESCRIPTION
Fixes #8750.

OFFSET on a shared LEFT/FULL hash-join result body must continue the hash build-side iterator. When the same body is reused for NULL-extended unmatched build rows, it also needs to continue the matching unmatched scanner.

This change records separate matched, global-unmatched, and grace-unmatched continuations and dispatches OFFSET based on the current row path. Regression coverage exercises matched rows, unmatched pages, INSERT-from-SELECT, aggregates, ORDER BY, and indexed joins.

Validation:
- cargo fmt --all -- --check
- cargo check -p turso_core
- cargo run --manifest-path ../../testing/sqltest/Cargo.toml --bin sqltest -- run turso-sqltests/join-limit-offset.sqltest --backend rust (8 passed)
