### PR TITLE
fix: preserve recursive CTE self-reference affinity

### DIFF
--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -2633,12 +2633,12 @@ impl JoinedTable {
         explicit_columns: Option<&[String]>,
     ) -> Result<Self> {
         let mut columns = query_output_columns(query, explicit_columns)?;
-        // The recursive self-reference reads SQLite's queue table, whose
-        // columns have no declared type: comparisons in the recursive term
-        // see the stored value without the anchor query's affinity. Only the
-        // outer read of the CTE keeps the derived affinity.
+        // The recursive self-reference has no declared affinity. Keep the
+        // anchor-derived affinity on the outer CTE relation, but make the
+        // queue input neutral so comparison rules can use the other operand's
+        // affinity (for example, a TEXT parent column).
         for column in columns.iter_mut() {
-            column.override_affinity(Affinity::Blob);
+            column.override_affinity(Affinity::None);
         }
         let table = Table::RecursiveCteInput(Arc::new(RecursiveCteInput {
             name: identifier.clone(),

--- a/sqlite/conformance/sqlite-sqltests/recursive-cte.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/recursive-cte.sqltest
@@ -1972,6 +1972,32 @@ expect {
     1
 }
 
+# A recursive parent lookup must keep traversing TEXT values when the recursive
+# self-reference is used from a DELETE subquery.
+test recursive-cte-text-parent-chain-delete {
+    CREATE TABLE parent_chain(id INTEGER, parent_id TEXT);
+    INSERT INTO parent_chain VALUES(1, NULL), (2, '1'), (3, '2');
+    WITH RECURSIVE ancestors(id) AS (
+        SELECT id FROM parent_chain WHERE parent_id IS NULL
+        UNION ALL
+        SELECT parent_chain.id
+        FROM parent_chain JOIN ancestors ON parent_chain.parent_id = ancestors.id
+    )
+    SELECT group_concat(id) FROM ancestors;
+    WITH RECURSIVE ancestors(id) AS (
+        SELECT id FROM parent_chain WHERE parent_id IS NULL
+        UNION ALL
+        SELECT parent_chain.id
+        FROM parent_chain JOIN ancestors ON parent_chain.parent_id = ancestors.id
+    )
+    DELETE FROM parent_chain WHERE id IN (SELECT id FROM ancestors);
+    SELECT count(*) FROM parent_chain;
+}
+expect {
+    1,2,3
+    0
+}
+
 # Seven recursive CTEs at the 2000-column limit need well over 65535 registers
 # in one program; register-carrying instruction fields must not overflow.
 test recursive-cte-many-max-width-ctes-no-register-overflow {


### PR DESCRIPTION
Fixes #8754.

Recursive CTE self-reference columns represent the queue input and do not have declared affinity. Reusing anchor-derived affinity for that input can coerce a TEXT parent key to numeric and stop traversal early, which makes DELETE ... WHERE id IN (recursive CTE) leave rows behind.

Keep the queue input affinity neutral while preserving anchor-derived affinity for the outer CTE relation. Add a regression covering a TEXT parent chain consumed by a DELETE subquery.

Validation:
- cargo fmt --all -- --check
- cargo check -p turso_core
- sqlite-sqltests/recursive-cte.sqltest with Rust backend, 119 passed
