### PR TITLE
fix: preserve integer precision in real in seeks

### DIFF
--- a/core/translate/optimizer/access_method.rs
+++ b/core/translate/optimizer/access_method.rs
@@ -608,7 +608,14 @@ pub(super) fn choose_best_in_seek_candidate(
                 continue;
             }
 
-            let affinity = if let Some(col_pos) = constraint.table_col_pos {
+            let affinity = if let Some(comparison_affinity) = constraint.comparison_affinity {
+                // The key must use the affinity of the comparison, rather than
+                // the storage column. In particular, a REAL column compared
+                // with a literal has NUMERIC comparison affinity. REAL
+                // affinity would round a large integer RHS to f64 before the
+                // b-tree seek and could probe a neighboring key.
+                comparison_affinity
+            } else if let Some(col_pos) = constraint.table_col_pos {
                 btree
                     .columns()
                     .get(col_pos)

--- a/core/translate/optimizer/constraints.rs
+++ b/core/translate/optimizer/constraints.rs
@@ -856,9 +856,16 @@ pub fn constraints_from_where_clause(
                     .unwrap_or(params.rows_per_table_fallback as u64)
                     as f64;
                 let selectivity = estimate_in_selectivity(estimated_values, row_count, *not);
-                // SQLite's `comparisonAffinity` for IN-list (`x IN (lit, ...)`)
-                // is the LHS column's affinity; the RHS literals are not folded.
-                let cmp_aff = Some(get_expr_affinity(lhs, Some(table_references), None));
+                // SQLite's comparison affinity for an IN-list follows the
+                // comparison rule: a lone numeric column affinity collapses to
+                // NUMERIC. This keeps integer RHS values exact when an index
+                // seek materializes the list (REAL affinity would round them).
+                let cmp_aff = Some(comparison_affinity(
+                    lhs.as_ref(),
+                    Affinity::None,
+                    Some(table_references),
+                    None,
+                ));
 
                 match lhs.as_ref() {
                     ast::Expr::Column { table, column, .. }

--- a/sqlite/conformance/sqlite-sqltests/index_seek_comparison_affinity.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/index_seek_comparison_affinity.sqltest
@@ -163,3 +163,26 @@ test issue-6715-real-affinity-seek-computed-expr {
 expect {
 0|1
 }
+
+# #8755: an indexed REAL IN-list must keep an integer RHS exact. Applying REAL
+# affinity to the ephemeral seek key rounds 9007199254740993 onto the stored
+# 9007199254740992 and incorrectly returns (and deletes) that row.
+setup issue-8755-real-in-list-schema {
+    CREATE TABLE t(x REAL);
+    INSERT INTO t VALUES(9007199254740992);
+    CREATE INDEX t_x ON t(x);
+}
+
+@setup issue-8755-real-in-list-schema
+test issue-8755-real-in-list-keeps-integer-exact {
+    SELECT count(*) FROM t WHERE x IN (9007199254740993);
+    SELECT (SELECT count(*) FROM t WHERE x IN (9007199254740993)),
+           (SELECT count(*) FROM t WHERE x NOT IN (9007199254740993));
+    DELETE FROM t WHERE x IN (9007199254740993);
+    SELECT count(*) FROM t;
+}
+expect {
+0
+0|1
+1
+}


### PR DESCRIPTION
Fixes #8755.

An index-backed IN-list was materializing RHS keys with the REAL column affinity. For integer literals beyond 2^53, that conversion rounded the key to a neighboring double and made the seek match a row that the list did not contain.

Use the resolved comparison affinity for IN-seek keys. A lone numeric column affinity resolves to NUMERIC, preserving integer RHS values while retaining text coercion and existing index compatibility checks. Add a regression covering SELECT, IN/NOT IN, and DELETE.

Validation:
- cargo fmt --all -- --check
- cargo check -p turso_core
- cargo test -p turso_core comparison_affinity --lib (build and test command passed; no tests matched the filter)
- in-index-seek.sqltest: 65 passed
- index_seek_comparison_affinity.sqltest: 10 passed
