### PR TITLE
fix: preserve scalar subquery column affinity

### DIFF
--- a/core/translate/optimizer/unnest.rs
+++ b/core/translate/optimizer/unnest.rs
@@ -636,6 +636,7 @@ fn try_rewrite_single_value_aggregate(
             no_reorder: false,
         }),
         subquery_id,
+        resolver,
     )?;
     // A scalar subquery result has no text order. Do not give its replacement
     // the text order of the grouped table's first result column.

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -12,6 +12,7 @@ use crate::{
         expression_index::{normalize_expr_for_index_matching, single_table_column_usage},
         optimizer::constraints::{BinaryExprSide, SeekRangeConstraint},
         planner::determine_where_to_eval_term,
+        Resolver,
     },
     types::SeekOp,
     util::exprs_are_equivalent,
@@ -44,8 +45,12 @@ use super::emitter::OperationMode;
 ///
 /// The affinity (and whether it's a real declared one) determines comparison
 /// behavior in IN expressions, etc.
-fn infer_type_from_expr(expr: &ast::Expr, tables: Option<&TableReferences>) -> Affinity {
-    get_expr_affinity(expr, tables, None)
+fn infer_type_from_expr(
+    expr: &ast::Expr,
+    tables: Option<&TableReferences>,
+    resolver: Option<&Resolver>,
+) -> Affinity {
+    get_expr_affinity(expr, tables, resolver)
 }
 
 /// Computes the affinity of column `i` of a compound (UNION/INTERSECT/EXCEPT)
@@ -2425,6 +2430,7 @@ impl Operation {
 fn query_output_columns(
     plan: &Plan,
     explicit_columns: Option<&[String]>,
+    resolver: Option<&Resolver>,
 ) -> Result<alloc::Vec<Column>> {
     let (result_columns, table_references): (&[ResultSetColumn], &TableReferences) = match plan {
         Plan::Select(select_plan) => (&select_plan.result_columns, &select_plan.table_references),
@@ -2468,7 +2474,7 @@ fn query_output_columns(
                 .as_ref()
                 .map(|arms| compound_column_affinity(arms, column_index))
                 .unwrap_or_else(|| {
-                    infer_type_from_expr(&result_column.expr, Some(table_references))
+                    infer_type_from_expr(&result_column.expr, Some(table_references), resolver)
                 });
             let column_type = affinity.to_type();
             let mut column = Column::new(
@@ -2522,12 +2528,14 @@ impl JoinedTable {
         plan: SelectPlan,
         join_info: Option<JoinInfo>,
         internal_id: TableInternalId,
+        resolver: &Resolver,
     ) -> Result<Self> {
         let mut columns = plan
             .result_columns
             .iter()
             .map(|rc| {
-                let affinity = infer_type_from_expr(&rc.expr, Some(&plan.table_references));
+                let affinity =
+                    infer_type_from_expr(&rc.expr, Some(&plan.table_references), Some(resolver));
                 let col_type = affinity.to_type();
                 let mut column = Column::new(
                     rc.name(&plan.table_references).map(String::from),
@@ -2592,8 +2600,9 @@ impl JoinedTable {
         explicit_columns: Option<&[String]>,
         cte_id: Option<usize>,
         materialize_hint: bool,
+        resolver: &Resolver,
     ) -> Result<Self> {
-        let columns = query_output_columns(&plan, explicit_columns)?;
+        let columns = query_output_columns(&plan, explicit_columns, Some(resolver))?;
         // Get result columns and table references from the plan
         // materialize_hint is set true for explicit WITH ... AS MATERIALIZED hint.
         // Multi-reference CTEs are also detected at emission time via reference counting,
@@ -2631,8 +2640,9 @@ impl JoinedTable {
         query: &Plan,
         internal_id: TableInternalId,
         explicit_columns: Option<&[String]>,
+        resolver: &Resolver,
     ) -> Result<Self> {
-        let mut columns = query_output_columns(query, explicit_columns)?;
+        let mut columns = query_output_columns(query, explicit_columns, Some(resolver))?;
         // The recursive self-reference reads SQLite's queue table, whose
         // columns have no declared type: comparisons in the recursive term
         // see the stored value without the anchor query's affinity. Only the

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -2592,6 +2592,7 @@ impl JoinedTable {
     /// If `cte_id` is provided, this subquery is a CTE reference that can share materialized data.
     /// If `materialize_hint` is true, the CTE was declared with AS MATERIALIZED and should always
     /// be materialized regardless of reference count.
+    #[allow(clippy::too_many_arguments)]
     pub fn new_subquery_from_plan(
         identifier: String,
         plan: Plan,

--- a/core/translate/planner.rs
+++ b/core/translate/planner.rs
@@ -1289,6 +1289,7 @@ fn plan_cte(
                 explicit_columns,
                 Some(cte_definition.cte_id),
                 cte_definition.materialize_hint,
+                resolver,
             )
         }
         Plan::Delete(_) | Plan::Update(_) => {
@@ -1408,6 +1409,7 @@ fn prepare_recursive_cte_plan(
         &initial_query,
         program.table_reference_counter.next(),
         explicit_columns,
+        resolver,
     )?;
     let input_table_id = input_table.internal_id;
 
@@ -1654,6 +1656,7 @@ fn parse_from_clause_table(
                 None,  // No explicit columns for regular subqueries
                 None,  // Regular inline subqueries don't have a CTE identity
                 false, // No materialize hint for inline subqueries
+                resolver,
             )?);
             Ok(())
         }
@@ -1799,6 +1802,7 @@ fn parse_table(
                     explicit_columns,
                     cte_id,
                     materialize_hint,
+                    resolver,
                 )?;
                 if let Some(alias) = alias {
                     joined_table.identifier = alias;

--- a/core/translate/window.rs
+++ b/core/translate/window.rs
@@ -257,6 +257,7 @@ fn prepare_window_subquery(
         inner_plan,
         None,
         subquery_id,
+        resolver,
     )?;
 
     // Verify that the subquery has the expected database ID.

--- a/sqlite/conformance/sqlite-sqltests/from-subquery-affinity.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/from-subquery-affinity.sqltest
@@ -60,6 +60,14 @@ expect {
 }
 
 @setup text-column-derived-table-schema
+test scalar-subquery-through-derived-table-keeps-selected-column-affinity {
+    SELECT x FROM (SELECT (SELECT a FROM t1) AS x) WHERE x = 1;
+}
+expect {
+1
+}
+
+@setup text-column-derived-table-schema
 test derived-table-literal-column-not-in-excludes-match {
     SELECT a FROM t1 WHERE a NOT IN (SELECT x FROM (SELECT 1 AS x)) ORDER BY a;
 }


### PR DESCRIPTION
## Summary

- thread the resolver through subquery, CTE, recursive CTE, and window subquery output-column inference
- preserve scalar subquery selected-column affinity when the result is exposed through a derived table
- add a regression test for a TEXT scalar subquery compared with an integer literal

## Validation

- `cargo fmt --all -- --check`
- `cargo check`
- `cargo run --manifest-path ..\\..\\testing\\sqltest\\Cargo.toml --bin sqltest -- run sqlite-sqltests/from-subquery-affinity.sqltest --binary ..\\..\\target\\debug\\tursodb` (12 passed)

Fixes #8730
