### PR TITLE
core/io: default uring sync to syscall fsync

### DIFF
--- a/core/io/io_uring.rs
+++ b/core/io/io_uring.rs
@@ -20,7 +20,7 @@ use std::{
     io::ErrorKind,
     ops::Deref,
     os::{fd::AsFd, unix::io::AsRawFd},
-    sync::Arc,
+    sync::{Arc, OnceLock},
 };
 use tracing::{debug, trace, warn};
 
@@ -637,6 +637,18 @@ fn get_key(c: Completion) -> u64 {
     Arc::into_raw(c.get_inner().clone()) as u64
 }
 
+fn uring_syscall_fsync_enabled() -> bool {
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    // Default on: FSYNC-via-ring was the dominant MVCC FULL commit tax.
+    // Opt out with TURSO_URING_SYSCALL_FSYNC=0|false|off.
+    *ENABLED.get_or_init(|| {
+        match std::env::var_os("TURSO_URING_SYSCALL_FSYNC") {
+            None => true,
+            Some(v) => v != "0" && v != "false" && v != "off",
+        }
+    })
+}
+
 #[inline(always)]
 /// convert the user_data back to an Completion pointer
 fn completion_from_key(key: u64) -> Completion {
@@ -797,6 +809,18 @@ impl File for UringFile {
     }
 
     fn sync(&self, c: Completion, _sync_type: crate::io::FileSyncType) -> Result<Completion> {
+        // Keep writes on the ring; durability is blocking fsync(2) by default.
+        // TURSO_URING_SYSCALL_FSYNC=0 forces FSYNC via the ring.
+        if uring_syscall_fsync_enabled() {
+            trace!("sync() via syscall fsync");
+            let result = unsafe { libc::fsync(self.file.as_raw_fd()) };
+            if result == -1 {
+                let e = std::io::Error::last_os_error();
+                return Err(io_error(e, "sync"));
+            }
+            c.complete(0);
+            return Ok(c);
+        }
         trace!("sync()");
         let fd = io_uring::types::Fd(self.file.as_raw_fd());
         let sync = io_uring::opcode::Fsync::new(fd)


### PR DESCRIPTION
## Description

Default `UringFile::sync` to blocking `fsync(2)` on the Linux io_uring backend, while leaving data writes on io_uring (`IORING_OP_WRITE` / SQPOLL).

Before this change, FULL durability on `--io io_uring` submitted `IORING_OP_FSYNC` on the ring. That path dominated MVCC commit latency. After this change, writes still go through the ring, and sync uses the same `fsync(2)` syscall path as `--io syscall`.

Opt out (force FSYNC via the ring again):

```bash
TURSO_URING_SYSCALL_FSYNC=0   # also: false | off
```

Code: `core/io/io_uring.rs` (`uring_syscall_fsync_enabled()`, default on).

Out of scope for this PR: park waiters, `IOSQE_IO_LINK`, coalesce window, `fdatasync`, CQ peek.

## Motivation and context

On concurrent MVCC commits with `PRAGMA synchronous=FULL`, tip-uring was far behind tip-syscall because ring FSYNC paid a large durability tax. Hybrid keeps the product story on io_uring for writes and removes that tax from the sync path.

### Benchmark gate

| Item | Value |
| --- | --- |
| Host | AWS EC2 **`c6id.16xlarge`** (`us-east-1a`) |
| Storage | Local NVMe instance storage mounted at `/mnt/nvme` (not EBS root) |
| Binary | release `perf/throughput` (`txn-throughput`) |
| Engine | Turso MVCC, `--io io_uring` (hero) vs ring-FSYNC control vs `--io syscall` / SQLite references |
| Sync | `PRAGMA synchronous=FULL` |
| Group commit | `PRAGMA mvcc_group_commit=yes` (`--group-commit` harness) |
| Checkpointer | Passive, 1000 ms |
| Workload | closed-loop, 100-row transactions per commit |
| Connections | c ∈ {1, 2, 4, 8} |
| Duration | 30 s measure + 5 s warmup, mean of 3 runs |
| Metrics | TPS mean from `*-result.csv`; latency eCDF / p99 from closed-loop samples |

### Results (hybrid default vs previous tip-uring ring-FSYNC)

| c | hybrid TPS | ring-FSYNC TPS | delta |
| --: | --: | --: | --: |
| 1 | 1101 | 846 | +30.1% |
| 2 | 1922 | 1327 | +44.8% |
| 4 | 3143 | 1812 | +73.5% |
| 8 | 5127 | 2739 | +87.2% |

Same gate, SQLite reference (talk scoreboard): hybrid is ~45% / ~65% of SQLite at c=1 / c=2, and ahead of SQLite at c=4 (+22%) and c=8 (+85%). tip-syscall remains the uring-preserving ceiling (e.g. ~5842 TPS at c=8).

## Description of AI Usage

AI-assisted hillclimb and PR drafting (Cursor agents): forensics on the FULL commit path, hypothesis measurement on the EC2 gate above, and wording of this description. The change itself is a small, reviewed edit in `core/io/io_uring.rs`. Measured keep/revert decisions used the frozen `txn-throughput` gate, not code inspection alone.