### PR TITLE
optimizer: respect collation on expression index seeks

### DIFF
--- a/core/translate/optimizer/constraints.rs
+++ b/core/translate/optimizer/constraints.rs
@@ -1263,6 +1263,15 @@ pub fn constraints_from_where_clause(
                         if !constraint.satisfies_index_affinity(idx_col_aff) {
                             continue;
                         }
+                    } else {
+                        let index_collation = index.columns[position_in_index]
+                            .collation
+                            .unwrap_or_default();
+                        if get_collseq_from_expr(constraining_expr, table_references)?
+                            .is_some_and(|collation| collation != index_collation)
+                        {
+                            continue;
+                        }
                     }
                     if let Some(index_candidate) = cs.candidates.iter_mut().find_map(|candidate| {
                         if candidate.index.as_ref().is_some_and(|i| {

--- a/sqlite/conformance/sqlite-sqltests/expression-index-collation.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/expression-index-collation.sqltest
@@ -1,0 +1,17 @@
+@database :memory:
+
+@cross-check-integrity
+test expression-index-collation-mismatch {
+    CREATE TABLE t(a TEXT, c INTEGER);
+    INSERT INTO t VALUES('A',1),('a',2),('b',3);
+    CREATE INDEX ix ON t(lower(a));
+    SELECT group_concat(c, ' ') FROM t WHERE lower(a) = 'A' COLLATE NOCASE;
+    SELECT group_concat(c, ' ') FROM t WHERE lower(a) > 'A' COLLATE NOCASE;
+    DELETE FROM t WHERE lower(a) > 'A' COLLATE NOCASE;
+    SELECT group_concat(c, ' ') FROM t;
+}
+expect {
+    1 2
+    3
+    1 2
+}


### PR DESCRIPTION
An expression index stores keys using its declared collation, but Turso currently uses that index for comparisons with a different explicit `COLLATE` clause. The seek can miss matching rows or include excluded rows, and a range DELETE can remove the whole table.

This skips an expression index when its collation does not match the comparison's constraining expression, allowing the full predicate to evaluate with the requested collation.

Tests: focused Rust SQL test covering equality, range, and DELETE behavior; it fails on the parent commit and passes with this change.

Fixes #8739
