### PR TITLE
Fix rowid alias affinity in trigger body expressions

### DIFF
--- a/core/translate/expr/affinity.rs
+++ b/core/translate/expr/affinity.rs
@@ -98,6 +98,7 @@ pub(crate) fn get_expr_affinity(
             }
             Affinity::None
         }
+        ast::Expr::Variable(variable) if variable.rowid_alias => Affinity::Integer,
         ast::Expr::SubqueryResult {
             subquery_id,
             query_type: ast::SubqueryType::RowValue { num_regs, .. },

--- a/core/translate/trigger_exec.rs
+++ b/core/translate/trigger_exec.rs
@@ -196,15 +196,22 @@ struct TriggerSubprogramContext {
     db_name: Option<ast::Name>,
 }
 
-fn variable_from_parameter_index(index: NonZero<usize>, col_type: Option<&str>) -> Expr {
+fn variable_from_parameter_index(
+    index: NonZero<usize>,
+    col_type: Option<&str>,
+    rowid_alias: bool,
+) -> Expr {
     let nz = u32::try_from(index.get())
         .ok()
         .and_then(std::num::NonZeroU32::new)
         .expect("trigger parameter index must fit into NonZeroU32");
-    match col_type {
-        Some(ty) => Expr::Variable(ast::Variable::indexed_typed(nz, ty)),
-        None => Expr::Variable(ast::Variable::indexed(nz)),
-    }
+    let variable = match (col_type, rowid_alias) {
+        (Some(ty), true) => ast::Variable::indexed_rowid_alias(nz, ty),
+        (Some(ty), false) => ast::Variable::indexed_typed(nz, ty),
+        (None, false) => ast::Variable::indexed(nz),
+        (None, true) => ast::Variable::indexed_rowid_alias(nz, "INTEGER"),
+    };
+    Expr::Variable(variable)
 }
 
 impl TriggerSubprogramContext {
@@ -434,6 +441,7 @@ fn rewrite_trigger_expr_single_for_subprogram(
                                 ctx.get_new_rowid_param()
                                     .expect("NEW parameters must be provided"),
                                 ty,
+                                true,
                             );
                             return Ok(());
                         }
@@ -442,6 +450,7 @@ fn rewrite_trigger_expr_single_for_subprogram(
                                 ctx.get_new_param(idx)
                                     .expect("NEW parameters must be provided"),
                                 ty,
+                                false,
                             );
                             return Ok(());
                         } else {
@@ -454,6 +463,7 @@ fn rewrite_trigger_expr_single_for_subprogram(
                             ctx.get_new_rowid_param()
                                 .expect("NEW parameters must be provided"),
                             None,
+                            true,
                         );
                         return Ok(());
                     }
@@ -476,6 +486,7 @@ fn rewrite_trigger_expr_single_for_subprogram(
                                 ctx.get_old_rowid_param()
                                     .expect("OLD parameters must be provided"),
                                 ty,
+                                true,
                             );
                             return Ok(());
                         }
@@ -484,6 +495,7 @@ fn rewrite_trigger_expr_single_for_subprogram(
                                 ctx.get_old_param(idx)
                                     .expect("OLD parameters must be provided"),
                                 ty,
+                                false,
                             );
                             return Ok(());
                         } else {
@@ -496,6 +508,7 @@ fn rewrite_trigger_expr_single_for_subprogram(
                             ctx.get_old_rowid_param()
                                 .expect("OLD parameters must be provided"),
                             None,
+                            true,
                         );
                         return Ok(());
                     }

--- a/sqlite/conformance/sqlite-sqltests/trigger-before-insert-affinity.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/trigger-before-insert-affinity.sqltest
@@ -239,3 +239,26 @@ test rowid-keeps-integer-affinity {
 expect {
     fired
 }
+
+test trigger-body-rowid-alias-keeps-integer-affinity {
+    CREATE TABLE t(id INTEGER PRIMARY KEY, v);
+    CREATE TABLE u(ref);
+    INSERT INTO t VALUES(1, 'x'), (2, 'y');
+    INSERT INTO u VALUES('1'), ('2');
+
+    CREATE TRIGGER tr_delete AFTER DELETE ON t
+      BEGIN DELETE FROM u WHERE ref = OLD.id; END;
+    DELETE FROM t WHERE id = 1;
+    SELECT count(*) FROM u;
+
+    DELETE FROM u;
+    INSERT INTO u VALUES('1');
+    CREATE TRIGGER tr_insert AFTER INSERT ON t
+      BEGIN DELETE FROM u WHERE ref = NEW.id; END;
+    INSERT INTO t VALUES(1, 'z');
+    SELECT count(*) FROM u;
+}
+expect {
+    1
+    0
+}

--- a/sqlite/parser/src/ast.rs
+++ b/sqlite/parser/src/ast.rs
@@ -624,6 +624,11 @@ pub struct Variable {
     pub name: Option<Box<str>>,
     /// Type of the source column, if known (e.g. from trigger NEW/OLD rewrite).
     pub col_type: Option<Box<str>>,
+    /// Whether this variable is the INTEGER-affinity rowid alias from a
+    /// trigger's NEW/OLD row. Ordinary trigger columns intentionally have no
+    /// affinity, even when their declared type is known.
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub rowid_alias: bool,
     /// True for an explicit `?N` marker. Numbered markers carry no allocated
     /// name; their "?N" spelling is derived from the index on demand.
     #[cfg_attr(feature = "serde", serde(default))]
@@ -636,6 +641,7 @@ impl Variable {
             index,
             name: None,
             col_type: None,
+            rowid_alias: false,
             numbered: false,
         }
     }
@@ -646,6 +652,7 @@ impl Variable {
             index,
             name: None,
             col_type: None,
+            rowid_alias: false,
             numbered: true,
         }
     }
@@ -659,8 +666,16 @@ impl Variable {
             } else {
                 Some(col_type.into())
             },
+            rowid_alias: false,
             numbered: false,
         }
+    }
+
+    /// A trigger NEW/OLD reference to an INTEGER PRIMARY KEY rowid alias.
+    pub fn indexed_rowid_alias(index: NonZeroU32, col_type: &str) -> Self {
+        let mut variable = Self::indexed_typed(index, col_type);
+        variable.rowid_alias = true;
+        variable
     }
 
     pub fn named(name: impl Into<Box<str>>, index: NonZeroU32) -> Self {
@@ -668,6 +683,7 @@ impl Variable {
             index,
             name: Some(name.into()),
             col_type: None,
+            rowid_alias: false,
             numbered: false,
         }
     }


### PR DESCRIPTION
SQLite gives `INTEGER PRIMARY KEY` rowid aliases INTEGER affinity in trigger `NEW`/`OLD` references. Turso currently loses that affinity when the reference is used inside a trigger body expression, so comparisons against untyped text values can miss rows and leave cleanup triggers ineffective.

This preserves the existing no-affinity behavior for ordinary trigger columns while marking rowid-alias variables explicitly and applying INTEGER affinity during comparison planning. Direct `NEW.rowid` and `OLD.rowid` references are covered as well.

Tests: the focused trigger-affinity SQL test file passes all 14 cases; the new trigger-body regression fails on the parent commit and passes with this change. `cargo fmt --all -- --check`, `cargo clippy -p turso_core --lib --all-features --locked -- --deny=warnings`, and `cargo test -p turso_parser --lib` pass. The full `turso_core` library suite reached 2,237 passing tests but has 90 pre-existing Windows file-lock/multiprocess-WAL failures in this environment.

Fixes #8719
