### PR TITLE
core: ignore virtual table column affinity in comparisons

### DIFF
--- a/core/translate/expr/affinity.rs
+++ b/core/translate/expr/affinity.rs
@@ -60,6 +60,13 @@ pub(crate) fn get_expr_affinity(
             }
             if let Some(tables) = referenced_tables {
                 if let Some((_, table_ref)) = tables.find_table_by_internal_id(*table) {
+                    // SQLite does not apply a virtual table module's declared
+                    // column type as expression affinity.  Module output is
+                    // runtime data, so a table-valued function column must
+                    // compare using the value it returns.
+                    if matches!(table_ref, Table::Virtual(_)) {
+                        return Affinity::Blob;
+                    }
                     if let Some(col) = table_ref.get_column_at(*column) {
                         if col.affinity() == Affinity::None {
                             return Affinity::None;

--- a/sqlite/conformance/sqlite-sqltests/affinity.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/affinity.sqltest
@@ -782,3 +782,26 @@ test affinity-sum-of-text-i64-min {
 expect {
     integer|-9223372036854775808
 }
+
+@cross-check-integrity
+test affinity-table-valued-function-columns {
+    CREATE TABLE t(x TEXT);
+    CREATE TABLE u(x TEXT);
+    CREATE TABLE w(c ANY, d);
+    INSERT INTO t VALUES('1'),('01'),('x');
+    INSERT INTO u VALUES('1'),('01'),('x');
+    INSERT INTO w VALUES(1, 1);
+    SELECT count(*) FROM t JOIN json_each('[1]') ON t.x = value;
+    SELECT count(*) FROM t JOIN generate_series(1, 1) ON t.x = value;
+    DELETE FROM u WHERE x IN (SELECT value FROM json_each('[1]'));
+    SELECT group_concat(x) FROM u;
+    SELECT count(*) FROM t JOIN w ON t.x = w.c;
+    SELECT count(*) FROM t JOIN w ON t.x = w.d;
+}
+expect {
+    0
+    0
+    1,01,x
+    2
+    0
+}


### PR DESCRIPTION
## Description

Fix virtual table output comparisons to use BLOB affinity. SQLite table-valued function columns have no declared expression affinity, even when a module schema includes a type name; inheriting that type made TEXT comparisons convert function output numerically.

Closes #8742.

## Motivation and context

`json_each.value` and `generate_series.value` were treated as numeric columns. A TEXT join or `IN` predicate therefore matched values such as `01` that SQLite leaves unmatched. Virtual table column references now use BLOB affinity, while ordinary table columns keep their declared affinity. The regression covers both table-valued functions and a real `ANY`/typeless table comparison.

## Description of AI Usage

Codex was used to reproduce the issue against the repository's `origin/main`, inspect the expression-affinity and virtual-table paths, implement the focused fix, add the SQL regression, and run the listed validation. The submitted change and test results were reviewed against the issue reproducer.

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p turso_core`
- `cargo test -p turso_core --lib translate::expr::affinity`
- SQLLogicTest `affinity.sqltest`: 59 passed
- SQLLogicTest `pragma/default.sqltest` and `pragma/foreign_key_list.sqltest`: 91 passed
- SQLLogicTest `generate_series.sqltest`: 6 passed
