### PR TITLE
core: preserve affinity for EXCEPT IN subqueries

### DIFF
--- a/core/translate/compound_select.rs
+++ b/core/translate/compound_select.rs
@@ -466,10 +466,25 @@ fn emit_compound_select(
             }
             CompoundOperator::Except => {
                 let mut new_index = false;
+                // Keep the EXCEPT working set separate from an IN-subquery's
+                // output index. The latter carries the LHS comparison
+                // affinity, while EXCEPT must first compute its set using
+                // the raw arm values. Reusing the output index would discard
+                // that affinity and make the membership probe compare by
+                // storage class.
+                let destination_has_affinity = matches!(
+                    &query_destination,
+                    QueryDestination::EphemeralIndex {
+                        affinity_str: Some(_),
+                        ..
+                    }
+                );
                 let (cursor_id, index) = match &right_most.query_destination {
                     QueryDestination::EphemeralIndex {
                         cursor_id, index, ..
-                    } if !index.has_rowid => (*cursor_id, index.clone()),
+                    } if !index.has_rowid && !destination_has_affinity => {
+                        (*cursor_id, index.clone())
+                    }
                     _ => {
                         new_index = true;
                         create_dedupe_index(program, plan, right_most)?

--- a/sqlite/conformance/sqlite-sqltests/affinity.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/affinity.sqltest
@@ -716,6 +716,26 @@ expect {
     text|1
 }
 
+# An EXCEPT subquery used by IN must retain its raw set-operation values while
+# applying the LHS comparison affinity when the result is probed. Reusing the
+# output index as EXCEPT's working index loses that conversion.
+@cross-check-integrity
+test affinity-in-except-subquery {
+    CREATE TABLE t (a INTEGER);
+    INSERT INTO t VALUES (1), (2), (3);
+    SELECT quote(a IN (SELECT '1' EXCEPT SELECT '9')) FROM t WHERE a = 1;
+    SELECT quote(a IN (SELECT '1' EXCEPT SELECT 1)) FROM t WHERE a = 1;
+    DELETE FROM t WHERE a IN (SELECT '1' EXCEPT SELECT '9');
+    SELECT group_concat(a) FROM t ORDER BY a;
+    SELECT quote(x) FROM (SELECT '1' AS x EXCEPT SELECT 1);
+}
+expect {
+    1
+    1
+    2,3
+    '1'
+}
+
 # ============================================
 # INTEGER/NUMERIC affinity at the i64 boundaries. The magnitude of i64::MIN is
 # one past i64::MAX, so the range check applied to the parsed digits has to be


### PR DESCRIPTION
## Description

Fixes #8724.

`IN (SELECT ... EXCEPT SELECT ...)` used the destination index as the
EXCEPT working index. The destination carries the comparison affinity from
the left-hand column, but EXCEPT configured that shared index with no
affinity. A compound result such as `SELECT '1' EXCEPT SELECT '9'` therefore
reached an INTEGER-column membership probe as TEXT and returned `NULL`.

The EXCEPT emitter now allocates a separate working index whenever the
destination carries output affinity. Raw arm values continue to determine
EXCEPT set membership, and the final read inserts the result into the output
index with the LHS comparison affinity. This also preserves direct EXCEPT
storage-class semantics.

### Validation

- `cargo fmt --all -- --check`
- `cargo check -p turso_core`
- `cargo clippy -p turso_core --lib --all-features --locked -- --deny=warnings`
- `cargo run --bin sqltest -- run sqlite/conformance/sqlite-sqltests/affinity.sqltest` (59 passed)

The regression covers the reported SELECT and DELETE, mixed text/integer
EXCEPT arms, and raw direct EXCEPT output.
