### PR TITLE
github: Disable Criterion plots in nightly benchmarks

### DIFF
--- a/scripts/nightly-bench.sh
+++ b/scripts/nightly-bench.sh
@@ -21,6 +21,12 @@
 #     started and finished even when it loses the log, so the step that never
 #     finished is the culprit.
 #
+# `run` also turns Criterion's plots off. Criterion draws them into
+# target/criterion, nothing in the nightly reads them, and drawing them is most
+# of the wall time: parser_benchmark takes 992 s with plots and 85 s without.
+# Only Criterion takes --noplot, so `run` asks each bench binary whether its
+# harness offers the flag rather than assuming.
+#
 # `check` keeps the step list in the workflow file in sync with the bench
 # targets cargo actually builds: a new bench with no step fails the job.
 set -euo pipefail
@@ -42,6 +48,13 @@ built_benches() {
     jq -r 'select(.reason == "compiler-artifact" and .executable != null
                   and (.target.kind | index("bench")))
            | .target.name' "$target_dir/nightly-bench-build.json" | sort -u
+}
+
+# Where cargo put one bench binary.
+bench_executable() {
+    jq -r --arg name "$1" 'select(.reason == "compiler-artifact" and .executable != null
+                  and (.target.kind | index("bench")) and .target.name == $name)
+           | .executable' "$target_dir/nightly-bench-build.json" | sort -u | tail -1
 }
 
 case "${1:-}" in
@@ -67,13 +80,22 @@ check)
     ;;
 run)
     name=$2
+    exe=$(bench_executable "$name")
+    if [ -z "$exe" ]; then
+        echo "error: cargo built no bench binary named $name; run '$0 build' first." >&2
+        exit 1
+    fi
+    harness_args=()
+    if "$exe" --help 2>&1 | grep -q -- --noplot; then
+        harness_args=(-- --noplot)
+    fi
     # Address-space cap in KiB. Well under the 8 GiB runner, well above the
     # ~2.5 GiB the biggest benchmark reaches.
     cap_kb=${NIGHTLY_BENCH_MEMORY_CAP_KB:-6291456}
     echo "free -m before $name:"
     free -m
     ulimit -v "$cap_kb"
-    cargo bench --bench "$name" --features bench 2>&1 | tee -a output.txt
+    cargo bench --bench "$name" --features bench "${harness_args[@]}" 2>&1 | tee -a output.txt
     echo "free -m after $name:"
     free -m
     ;;


### PR DESCRIPTION
We don't really need them, but they're slowing down the runs some.