### PR TITLE
fix core: stop implicit collation leaking through expressions

### DIFF
--- a/core/translate/collate.rs
+++ b/core/translate/collate.rs
@@ -473,17 +473,27 @@ fn get_collseq_parts_from_expr_with_symbols(
     let mut maybe_explicit_collseq = None;
 
     walk_expr(top_expr, &mut |expr: &Expr| -> Result<WalkControl> {
-        match expr {
-            Expr::Collate(_, seq) => {
-                // Only store the first (leftmost) COLLATE operator we find
-                if maybe_explicit_collseq.is_none() {
-                    maybe_explicit_collseq = Some(
-                        resolve_collation_name(seq.as_str(), symbol_table).unwrap_or_default(),
-                    );
-                }
-                // Skip children since we've found a COLLATE operator
-                return Ok(WalkControl::SkipChildren);
+        if let Expr::Collate(_, seq) = expr {
+            // Only store the first (leftmost) COLLATE operator we find
+            if maybe_explicit_collseq.is_none() {
+                maybe_explicit_collseq =
+                    Some(resolve_collation_name(seq.as_str(), symbol_table).unwrap_or_default());
             }
+            // Skip children since we've found a COLLATE operator
+            return Ok(WalkControl::SkipChildren);
+        }
+        Ok(WalkControl::Continue)
+    })?;
+
+    // SQLite carries an implicit column collation through only a bare column,
+    // parenthesization, unary `+`, or CAST. Computed expressions such as `||`,
+    // functions, and CASE are collation-opaque unless they contain an
+    // explicit COLLATE operator (handled by the walk above).
+    fn implicit_column_collation(
+        expr: &Expr,
+        referenced_tables: &TableReferences,
+    ) -> Result<Option<CollationSeq>> {
+        match expr {
             Expr::Column { table, column, .. } => {
                 let (_, table_ref) = referenced_tables
                     .find_table_by_internal_id(*table)
@@ -491,28 +501,32 @@ fn get_collseq_parts_from_expr_with_symbols(
                 let column = table_ref
                     .get_column_at(*column)
                     .ok_or_else(|| crate::LimboError::ParseError("column not found".to_string()))?;
-                if maybe_column_collseq.is_none() {
-                    maybe_column_collseq = column.collation_opt();
-                }
-                return Ok(WalkControl::Continue);
+                Ok(column.collation_opt())
             }
             Expr::RowId { table, .. } => {
                 let (_, table_ref) = referenced_tables
                     .find_table_by_internal_id(*table)
                     .ok_or_else(|| crate::LimboError::ParseError("table not found".to_string()))?;
-                if let Some(btree) = table_ref.btree() {
-                    if let Some((_, rowid_alias_col)) = btree.get_rowid_alias_column() {
-                        if maybe_column_collseq.is_none() {
-                            maybe_column_collseq = rowid_alias_col.collation_opt();
-                        }
-                    }
-                }
-                return Ok(WalkControl::Continue);
+                Ok(table_ref.btree().and_then(|btree| {
+                    btree
+                        .get_rowid_alias_column()
+                        .and_then(|(_, column)| column.collation_opt())
+                }))
             }
-            _ => {}
+            Expr::Parenthesized(exprs) if exprs.len() == 1 => {
+                implicit_column_collation(&exprs[0], referenced_tables)
+            }
+            Expr::Unary(turso_parser::ast::UnaryOperator::Positive, expr) => {
+                implicit_column_collation(expr, referenced_tables)
+            }
+            Expr::Cast { expr, .. } => implicit_column_collation(expr, referenced_tables),
+            _ => Ok(None),
         }
-        Ok(WalkControl::Continue)
-    })?;
+    }
+
+    if maybe_explicit_collseq.is_none() {
+        maybe_column_collseq = implicit_column_collation(top_expr, referenced_tables)?;
+    }
 
     Ok((maybe_explicit_collseq, maybe_column_collseq))
 }
@@ -694,12 +708,13 @@ mod tests {
     }
 
     #[test]
-    fn test_get_collseq_from_expr_column_plus_column_leftside_column_wins() {
+    fn test_get_collseq_from_expr_computed_column_expression_is_opaque() {
         let table_references = get_table_references_two_tables_single_column_with_collations(
             Some(CollationSeq::NoCase),
             Some(CollationSeq::Rtrim),
         );
-        // col1 + col2 -- col1's NOCASE collation wins since it's on the left side
+        // A computed expression does not inherit either column's implicit
+        // collation.
         let lhs = Expr::Column {
             database: None,
             table: TableInternalId::from(1),
@@ -714,7 +729,7 @@ mod tests {
         };
         let expr = Expr::binary(lhs, Operator::Add, rhs);
         let collseq = get_collseq_from_expr(&expr, &table_references).unwrap();
-        assert_eq!(collseq, Some(CollationSeq::NoCase));
+        assert_eq!(collseq, None);
     }
 
     #[test]

--- a/core/translate/expr/binary.rs
+++ b/core/translate/expr/binary.rs
@@ -100,7 +100,7 @@ pub(super) fn emit_binary_expr_scalar(
                 Some(resolver),
             )?,
         }
-        if op.is_comparison() {
+        if op.is_comparison() || matches!(program.curr_collation_ctx(), Some((_, false))) {
             program.reset_collation();
         }
         Ok(target_register)
@@ -169,12 +169,11 @@ pub(super) fn emit_binary_expr_scalar(
                 Some(resolver),
             )?,
         }
-        // Only reset collation for comparison operators, which consume it.
-        // Non-comparison operators (Concat, Add, etc.) must propagate the
-        // collation to the parent expression so that e.g.
-        //   (name COLLATE NOCASE || '') <> 'admin'
-        // correctly applies NOCASE to the Ne comparison.
-        if op.is_comparison() {
+        // Comparison operators consume their collation context. Computed
+        // expressions do not inherit an implicit column collation, while an
+        // explicit COLLATE inside the expression still applies to a parent
+        // comparison.
+        if op.is_comparison() || matches!(program.curr_collation_ctx(), Some((_, false))) {
             program.reset_collation();
         }
         Ok(target_register)

--- a/core/translate/expr/translator.rs
+++ b/core/translate/expr/translator.rs
@@ -3132,6 +3132,22 @@ pub fn translate_expr(
         }
     }?;
 
+    // A function call or CASE expression is a computed value and therefore
+    // does not inherit an implicit collation from one of its column inputs.
+    // An explicit COLLATE nested in the expression remains effective.
+    if matches!(
+        expr,
+        ast::Expr::Case { .. }
+            | ast::Expr::FunctionCall { .. }
+            | ast::Expr::FunctionCallStar { .. }
+    ) {
+        if let Some(collation) = explicit_collation(expr, Some(resolver))? {
+            program.set_collation(Some((collation, true)));
+        } else if matches!(program.curr_collation_ctx(), Some((_, false))) {
+            program.reset_collation();
+        }
+    }
+
     if let Some(span) = constant_span {
         program.constant_span_end(span);
     }

--- a/sqlite/conformance/sqlite-sqltests/collate.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/collate.sqltest
@@ -1456,6 +1456,33 @@ expect {
     0
 }
 
+@cross-check-integrity
+test collate_column_concat_drops_implicit_collation {
+    CREATE TABLE t (id INTEGER PRIMARY KEY, e TEXT COLLATE NOCASE);
+    INSERT INTO t VALUES (1, 'A'), (2, 'a');
+    SELECT group_concat(id) FROM t WHERE (e || '') = 'a' ORDER BY id;
+    SELECT group_concat(id) FROM t WHERE trim(e) = 'a' ORDER BY id;
+    SELECT group_concat(id) FROM t WHERE substr(e, 1) = 'a' ORDER BY id;
+    SELECT group_concat(id) FROM t WHERE coalesce(e, '') = 'a' ORDER BY id;
+    SELECT group_concat(id) FROM t WHERE replace(e, 'x', 'x') = 'a' ORDER BY id;
+    SELECT group_concat(id) FROM t WHERE (CASE WHEN 1 THEN e ELSE '' END) = 'a' ORDER BY id;
+    DELETE FROM t WHERE (e || '') = 'a';
+    SELECT group_concat(id) FROM t ORDER BY id;
+    DELETE FROM t;
+    INSERT INTO t VALUES (1, 'A'), (2, 'a');
+    SELECT group_concat(id) FROM t WHERE (e COLLATE NOCASE || '') = 'a' ORDER BY id;
+}
+expect {
+    2
+    2
+    2
+    2
+    2
+    2
+    1
+    1,2
+}
+
 # Tests for aggregate COLLATE not leaking to subsequent aggregates (#5539)
 
 setup agg_collate_schema {

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__correlated-subquery-count.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__correlated-subquery-count.snap
@@ -73,7 +73,7 @@ addr  opcode                 p1  p2  p3  p4            p5  comment
   46      Column              0   1  23                 0  r[23]=ephemeral(ephemeral_subquery_t2).count(*)
   47      NotNull            23  49   0                 0  r[23]!=NULL -> goto 49
   48      Integer             0  23   0                 0  r[23]=0
-  49      Lt                 23  24  54  Binary         0  if r[23]<r[24] goto 54
+  49      Lt                 23  24  54                 0  if r[23]<r[24] goto 54
   50      RowId               2  17   0                 0  r[17]=orders.rowid
   51      ColumnRange         2   2  18  2              0  r[18..19]=orders.order_date..total_amount
   52      RealAffinity       19   0   0                 0

--- a/sqlite/conformance/upstream/all.test
+++ b/sqlite/conformance/upstream/all.test
@@ -129,7 +129,7 @@ set test_files {
   collate5             fail
   collate6             fail
   collate7             fail
-  collate8             fail
+  collate8             pass
   collate9             fail
   collateA             pass
   collateB             pass


### PR DESCRIPTION
Fixes #8723

SQLite treats a declared column collation as implicit only when a comparison operand is a bare column or a transparent wrapper such as CAST, unary +, or parentheses. Computed expressions such as concatenation, scalar functions, and CASE fall back to BINARY unless they contain an explicit COLLATE.

This change scopes implicit column-collation lookup to transparent wrappers and clears implicit collation context after computed binary, function, and CASE expressions while preserving explicit COLLATE. The regression covers concatenation, trim, substr, coalesce, replace, CASE, DELETE behavior, and explicit COLLATE propagation.

Validation:
- cargo fmt --all -- --check
- cargo test -p turso_core --lib translate::collate
- cargo test -p turso_core --lib translate::expr
- cargo clippy -p turso_core --lib -- -D warnings -A dead_code -A unfulfilled_lint_expectations
- sqltest run sqlite/conformance/sqlite-sqltests/collate.sqltest --backend rust --filter collate_column_*
- sqltest run sqlite/conformance/sqlite-sqltests/collate.sqltest --backend cli --binary target/release/tursodb.exe --filter collate_column_*
- sqltest run sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/subqueries.sqltest --backend rust --snapshot-filter correlated-subquery-count --snapshot-mode=no

The full collate file still has one pre-existing `collate_distinct_rtrim` failure (expected 2, actual 5) reproduced on this branch and clean `origin/main`; it remains unchanged. The upstream `collate8` suite is now fully green, so its `all.test` status is blessed from `fail` to `pass`. The correlated count snapshot now records the cleared implicit collation metadata at bytecode address 49.
