### PR TITLE
replace raw unsafe affinity with safe comparison one

### DIFF
--- a/core/translate/optimizer/access_method.rs
+++ b/core/translate/optimizer/access_method.rs
@@ -9,7 +9,7 @@ use turso_parser::ast::{self, SortOrder, TableInternalId};
 use crate::alloc::{TursoIteratorExt, TursoTryWithCapacityExt, TursoVecExt};
 use crate::schema::Schema;
 use crate::stats::AnalyzeStats;
-use crate::translate::expr::{as_binary_components, walk_expr, WalkControl};
+use crate::translate::expr::{as_binary_components, comparison_affinity, walk_expr, WalkControl};
 use crate::translate::optimizer::constraints::{
     convert_to_vtab_constraint, expr_uses_custom_collation, ordered_ephemeral_key_columns,
     partial_index, partial_index_predicate_terms, BinaryExprSide, Constraint, ConstraintOperator,
@@ -608,7 +608,7 @@ pub(super) fn choose_best_in_seek_candidate(
                 continue;
             }
 
-            let affinity = if let Some(col_pos) = constraint.table_col_pos {
+            let lhs_affinity = if let Some(col_pos) = constraint.table_col_pos {
                 btree
                     .columns()
                     .get(col_pos)
@@ -617,6 +617,7 @@ pub(super) fn choose_best_in_seek_candidate(
             } else {
                 Affinity::Integer
             };
+            let affinity = comparison_affinity(lhs_affinity, Affinity::None, None, None);
             best_in_seek_cost = in_cost;
             best_in_seek = Some(ChosenInSeekCandidate {
                 index: candidate.index.clone(),

--- a/sqlite/conformance/sqlite-sqltests/index_seek_comparison_affinity.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/index_seek_comparison_affinity.sqltest
@@ -163,3 +163,18 @@ test issue-6715-real-affinity-seek-computed-expr {
 expect {
 0|1
 }
+
+# Indexed REAL col's IN seek mustn't round rhs integers past 2^53.
+setup real-affinity-in-list-schema {
+    CREATE TABLE t(x REAL);
+    INSERT INTO t VALUES(9007199254740992);
+    CREATE INDEX t_x ON t(x);
+}
+
+@setup real-affinity-in-list-schema
+test real-affinity-in-list-preserves-integer {
+    SELECT count(*) FROM t WHERE x IN (9007199254740993);
+}
+expect {
+0
+}

--- a/tests/integration/query_processing/test_in_seek.rs
+++ b/tests/integration/query_processing/test_in_seek.rs
@@ -47,3 +47,19 @@ fn large_indexed_in_list_uses_seek_loop() {
         "large IN-list regressed to residual scan:\n{plan}"
     );
 }
+
+#[test]
+fn indexed_real_column_in_list_does_not_lose_precision() {
+    let tmp_db = TempDatabase::new_empty();
+    let conn = tmp_db.connect_limbo();
+
+    limbo_exec_rows(&conn, "CREATE TABLE t(x REAL)");
+    limbo_exec_rows(&conn, "INSERT INTO t VALUES(9007199254740992)");
+    limbo_exec_rows(&conn, "CREATE INDEX t_x ON t(x)");
+
+    let rows = limbo_exec_rows(
+        &conn,
+        "SELECT count(*) FROM t WHERE x IN (9007199254740993)",
+    );
+    assert_eq!(rows, vec![vec![Value::Integer(0)]]);
+}

--- a/tests/integration/query_processing/test_in_seek.rs
+++ b/tests/integration/query_processing/test_in_seek.rs
@@ -47,19 +47,3 @@ fn large_indexed_in_list_uses_seek_loop() {
         "large IN-list regressed to residual scan:\n{plan}"
     );
 }
-
-#[test]
-fn indexed_real_column_in_list_does_not_lose_precision() {
-    let tmp_db = TempDatabase::new_empty();
-    let conn = tmp_db.connect_limbo();
-
-    limbo_exec_rows(&conn, "CREATE TABLE t(x REAL)");
-    limbo_exec_rows(&conn, "INSERT INTO t VALUES(9007199254740992)");
-    limbo_exec_rows(&conn, "CREATE INDEX t_x ON t(x)");
-
-    let rows = limbo_exec_rows(
-        &conn,
-        "SELECT count(*) FROM t WHERE x IN (9007199254740993)",
-    );
-    assert_eq!(rows, vec![vec![Value::Integer(0)]]);
-}


### PR DESCRIPTION
Fixes [#8755](https://github.com/tursodatabase/turso/issues/8755)

Replace raw unsafe affinity used by indexed IN seek with the safe comparison one which is already applied everywhere except for this case.

