### PR TITLE
tests: check the ephemeral temp file the statement actually owns

### DIFF
--- a/core/io/mod.rs
+++ b/core/io/mod.rs
@@ -368,6 +368,11 @@ impl TempFile {
             Self::new(io)
         }
     }
+
+    #[cfg(feature = "test_helper")]
+    pub(crate) fn dir(&self) -> Option<&std::path::Path> {
+        self.temp_dir.as_ref().map(|temp_dir| temp_dir.path())
+    }
 }
 
 #[cfg(all(test, target_os = "windows", feature = "fs"))]

--- a/core/statement.rs
+++ b/core/statement.rs
@@ -460,6 +460,12 @@ impl Statement {
         self.program.connection.set_mv_tx(mv_tx);
     }
 
+    /// Directories holding the temp files of this statement's open ephemeral cursors.
+    #[cfg(feature = "test_helper")]
+    pub fn ephemeral_temp_file_dirs(&self) -> Vec<std::path::PathBuf> {
+        self.state.ephemeral_temp_file_dirs()
+    }
+
     pub fn interrupt(&mut self) {
         self.state.interrupt();
     }

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -1058,6 +1058,15 @@ impl ProgramState {
         Some(format!("{:?}", self.registers[i]))
     }
 
+    #[cfg(feature = "test_helper")]
+    pub fn ephemeral_temp_file_dirs(&self) -> Vec<std::path::PathBuf> {
+        self.ephemeral_temp_files
+            .values()
+            .filter_map(|temp_file| temp_file.dir())
+            .map(|dir| dir.to_path_buf())
+            .collect()
+    }
+
     pub fn interrupt(&mut self) {
         self.execution_state = ProgramExecutionState::Interrupting;
     }

--- a/tests/integration/query_processing/test_ephemeral_cleanup.rs
+++ b/tests/integration/query_processing/test_ephemeral_cleanup.rs
@@ -1,38 +1,12 @@
-use crate::common::{limbo_exec_rows, ExecRows, TempDatabase};
+#![cfg(feature = "test_helper")]
+
+use crate::common::{limbo_exec_rows, TempDatabase};
 use rusqlite::types::Value;
-use std::collections::HashSet;
 use std::path::PathBuf;
-
-/// Snapshot all directory entries in the system temp dir.
-fn snapshot_temp_dir() -> HashSet<PathBuf> {
-    let temp_dir = std::env::temp_dir();
-    std::fs::read_dir(&temp_dir)
-        .expect("failed to read system temp dir")
-        .filter_map(|e| e.ok())
-        .map(|e| e.path())
-        .collect()
-}
-
-/// Find new directories that contain a `tursodb_temp_file` — these are leaked TempFiles.
-fn find_leaked_temp_files(before: &HashSet<PathBuf>, after: &HashSet<PathBuf>) -> Vec<PathBuf> {
-    after
-        .difference(before)
-        .filter(|p| p.is_dir() && p.join("tursodb_temp_file").exists())
-        .cloned()
-        .collect()
-}
-
-fn value_as_text(value: &Value) -> Option<&str> {
-    match value {
-        Value::Text(v) => Some(v.as_str()),
-        _ => None,
-    }
-}
+use turso_core::StepResult;
 
 #[test]
 fn test_ephemeral_temp_files_cleaned_up() {
-    let before = snapshot_temp_dir();
-
     let db = TempDatabase::new_empty();
     let conn = db.connect_limbo();
 
@@ -56,15 +30,52 @@ fn test_ephemeral_temp_files_cleaned_up() {
         "expected OpenEphemeral in EXPLAIN output"
     );
 
-    let rows: Vec<(i64,)> = conn.exec_rows("SELECT x FROM t_eph UNION SELECT x FROM t_eph");
-    assert_eq!(rows, vec![(1,), (2,), (3,)]);
+    let mut stmt = conn
+        .prepare("SELECT x FROM t_eph UNION SELECT x FROM t_eph")
+        .unwrap();
+    let mut rows: Vec<i64> = Vec::new();
+    let mut temp_file_dirs: Vec<PathBuf> = Vec::new();
+    loop {
+        match stmt.step().unwrap() {
+            StepResult::IO | StepResult::Yield | StepResult::Sleep { .. } => db.io.step().unwrap(),
+            StepResult::Row => {
+                if rows.is_empty() {
+                    temp_file_dirs = stmt.ephemeral_temp_file_dirs();
+                    assert!(
+                        !temp_file_dirs.is_empty(),
+                        "expected the ephemeral cursor to own a temp file while the query runs"
+                    );
+                    for dir in &temp_file_dirs {
+                        assert!(
+                            dir.exists(),
+                            "temp file directory {dir:?} was never created"
+                        );
+                    }
+                }
+                rows.push(stmt.row().unwrap().get::<i64>(0).unwrap());
+            }
+            StepResult::Done => break,
+            StepResult::Interrupt | StepResult::Busy => panic!("query did not run to completion"),
+        }
+    }
+    assert_eq!(rows, vec![1, 2, 3]);
 
-    // Drop connection and database so all ProgramState instances are dropped,
+    // Drop statement, connection and database so all ProgramState instances are dropped,
     // which should clean up any TempFile entries.
+    drop(stmt);
     drop(conn);
     drop(db);
 
-    let after = snapshot_temp_dir();
-    let leaked = find_leaked_temp_files(&before, &after);
+    let leaked: Vec<_> = temp_file_dirs
+        .into_iter()
+        .filter(|dir| dir.exists())
+        .collect();
     assert!(leaked.is_empty(), "Ephemeral temp files leaked: {leaked:?}");
+}
+
+fn value_as_text(value: &Value) -> Option<&str> {
+    match value {
+        Value::Text(v) => Some(v.as_str()),
+        _ => None,
+    }
 }


### PR DESCRIPTION
`test_ephemeral_temp_files_cleaned_up` fails intermittently on macOS, on
unrelated pull requests and on main. Example: run 34322371437 on main, and
run 34340484920 on a dependabot npm bump.

The test listed the machine-wide temp directory before and after running an
ephemeral query and called every new directory holding a `tursodb_temp_file`
a leak. That directory is shared with every other test process, and ephemeral
cursors, hash tables and spilling sorters all create exactly that directory
shape. CI runs 5614 tests at once, each in its own process, so at any moment
plenty of those directories are alive and owned by other tests. The names are
random, so the test could not tell them apart from its own and blamed one of
them. Nothing had leaked: the directory the CI failure named was deleted
normally as soon as the test that owned it finished.

Statements now report the temp directories of their open ephemeral cursors
under the `test_helper` feature, so the test asks for the paths it owns
instead of guessing. It checks the directory exists while the query runs and
is gone once the statement, connection and database are dropped.

Tests: looping the old test against a concurrently running integration suite
reproduced the CI failure within 40 iterations; the new test passed 80/80
under the same load. Leaking the directory in `TempFile`'s drop still fails
the test.