### PR TITLE
github: check Android native sync exports from ELF dynsym

### DIFF
--- a/.github/workflows/dotnet-publish.yml
+++ b/.github/workflows/dotnet-publish.yml
@@ -445,6 +445,18 @@ jobs:
             rm "$package_entries"
           done < <(find src -path '*/bin/Release/*.nupkg' -type f)
 
+          android_native=$(mktemp)
+          unzip -p "$native_package" runtimes/android-arm64/native/libturso_sdk_kit.so > "$android_native"
+          python3 scripts/check_elf_dynsym_exports.py "$android_native" \
+            turso_sync_database_new \
+            turso_sync_database_create \
+            turso_sync_database_open \
+            turso_sync_database_connect \
+            turso_sync_database_stats \
+            turso_sync_database_checkpoint \
+            turso_sync_database_deinit
+          rm "$android_native"
+
           static_packages=(
             "win-x64:turso_sdk_kit.lib"
             "win-arm64:turso_sdk_kit.lib"
@@ -717,22 +729,27 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          apk=$(find samples/MobilePackageConsumer/Android/bin/Release -name '*-Signed.apk' -print -quit)
+          apk=$(find samples/MobilePackageConsumer/Android/bin/Release -path '*android-arm64*' -name '*-Signed.apk' -print -quit)
+          if [ -z "$apk" ]; then
+            apk=$(find samples/MobilePackageConsumer/Android/bin/Release -name '*-Signed.apk' -print -quit)
+          fi
           if [ -z "$apk" ]; then
             echo "Android package consumer did not produce a signed APK"
             exit 1
           fi
+          echo "Checking Android APK $apk"
 
           native_entry=lib/arm64-v8a/libturso_sdk_kit.so
           if ! unzip -Z1 "$apk" | grep -Fxq "$native_entry"; then
             echo "$apk does not contain $native_entry"
+            unzip -Z1 "$apk" | grep -E 'lib/|\.so$' || true
             exit 1
           fi
 
           mkdir -p artifacts/mobile-android
           unzip -p "$apk" "$native_entry" > artifacts/mobile-android/libturso_sdk_kit.so
-          readelf="$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-readelf"
-          for symbol in \
+          echo "Extracted $native_entry ($(wc -c < artifacts/mobile-android/libturso_sdk_kit.so) bytes)"
+          python3 scripts/check_elf_dynsym_exports.py artifacts/mobile-android/libturso_sdk_kit.so \
             turso_sync_database_new \
             turso_sync_database_create \
             turso_sync_database_open \
@@ -740,12 +757,6 @@ jobs:
             turso_sync_database_stats \
             turso_sync_database_checkpoint \
             turso_sync_database_deinit
-          do
-            if ! "$readelf" --dyn-syms --wide artifacts/mobile-android/libturso_sdk_kit.so | grep -Eq "[[:space:]]${symbol}$"; then
-              echo "Android package asset does not export $symbol"
-              exit 1
-            fi
-          done
 
   validate-ios-package:
     needs: publish

--- a/bindings/dotnet/scripts/check_elf_dynsym_exports.py
+++ b/bindings/dotnet/scripts/check_elf_dynsym_exports.py
@@ -4,6 +4,13 @@ import struct
 import sys
 from pathlib import Path
 
+NAME = 0
+TYPE = 1
+OFFSET = 4
+SIZE = 5
+LINK = 6
+ENTRY_SIZE = 9
+
 
 def main() -> None:
     if len(sys.argv) == 2 and sys.argv[1] == "--self-test":
@@ -52,18 +59,33 @@ def elf64_with_dynsym(symbol: str) -> bytes:
     dynsym_offset += dynsym_pad
     section_offset = dynsym_offset + len(dynsym)
 
-    def section(name: int, typ: int, flags: int, offset: int, size: int, link: int, info: int, align: int, entsize: int) -> bytes:
-        return struct.pack("<IIQQQQIIQQ", name, typ, flags, 0, offset, size, link, info, align, entsize)
-
     sections = (
         bytes(64)
-        + section(1, 3, 0, shstrtab_offset, len(shstrtab), 0, 0, 1, 0)
-        + section(11, 3, 2, dynstr_offset, len(dynstr), 0, 0, 1, 0)
-        + section(19, 11, 2, dynsym_offset, len(dynsym), 2, 1, 8, 24)
+        + elf64_section(1, 3, 0, shstrtab_offset, len(shstrtab), 0, 0, 1, 0)
+        + elf64_section(11, 3, 2, dynstr_offset, len(dynstr), 0, 0, 1, 0)
+        + elf64_section(19, 11, 2, dynsym_offset, len(dynsym), 2, 1, 8, 24)
     )
     header = bytes([0x7F, 0x45, 0x4C, 0x46, 2, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0])
-    header += struct.pack("<HHIQQQIHHHHHH", 3, 62, 1, 0, 0, section_offset, 0, 64, 0, 0, 64, 4, 1)
+    header += struct.pack(
+        "<HHIQQQIHHHHHH", 3, 62, 1, 0, 0, section_offset, 0, 64, 0, 0, 64, 4, 1
+    )
     return header + shstrtab + dynstr + (b"\0" * dynsym_pad) + dynsym + sections
+
+
+def elf64_section(
+    name: int,
+    typ: int,
+    flags: int,
+    offset: int,
+    size: int,
+    link: int,
+    info: int,
+    align: int,
+    entsize: int,
+) -> bytes:
+    return struct.pack(
+        "<IIQQQQIIQQ", name, typ, flags, 0, offset, size, link, info, align, entsize
+    )
 
 
 def dynsym_names(path: Path) -> set[str]:
@@ -71,79 +93,78 @@ def dynsym_names(path: Path) -> set[str]:
     if data[:4] != b"\x7fELF":
         raise SystemExit(f"{path} is not an ELF file")
 
-    little = data[5] == 1
-    endian = "<" if little else ">"
+    layout = elf_layout(data, path)
+    dynsym = find_dynsym(data, layout, path)
+    return names_from_dynsym(data, layout, dynsym)
+
+
+def elf_layout(data: bytes, path: Path) -> dict:
+    endian = "<" if data[5] == 1 else ">"
     elf_class = data[4]
     if elf_class == 2:
-        section_header_offset = struct.unpack_from(endian + "Q", data, 40)[0]
-        section_header_size, section_count, string_table_index = struct.unpack_from(
-            endian + "HHH", data, 58
-        )
-        section_format = endian + "IIQQQQIIQQ"
-        name_index, type_index, offset_index, size_index, link_index, entry_size_index = (
-            0,
-            1,
-            4,
-            5,
-            6,
-            9,
-        )
-        symbol_format = endian + "IBBHQQ"
-        symbol_name_index = 0
-    elif elf_class == 1:
-        section_header_offset = struct.unpack_from(endian + "I", data, 32)[0]
-        section_header_size, section_count, string_table_index = struct.unpack_from(
-            endian + "HHH", data, 46
-        )
-        section_format = endian + "IIIIIIIIII"
-        name_index, type_index, offset_index, size_index, link_index, entry_size_index = (
-            0,
-            1,
-            4,
-            5,
-            6,
-            9,
-        )
-        symbol_format = endian + "IIIBBH"
-        symbol_name_index = 0
-    else:
-        raise SystemExit(f"{path} has unsupported ELF class {elf_class}")
+        return {
+            "endian": endian,
+            "section_header_offset": struct.unpack_from(endian + "Q", data, 40)[0],
+            "section_header_size": struct.unpack_from(endian + "H", data, 58)[0],
+            "section_count": struct.unpack_from(endian + "H", data, 60)[0],
+            "string_table_index": struct.unpack_from(endian + "H", data, 62)[0],
+            "section_format": endian + "IIQQQQIIQQ",
+            "symbol_format": endian + "IBBHQQ",
+        }
+    if elf_class == 1:
+        return {
+            "endian": endian,
+            "section_header_offset": struct.unpack_from(endian + "I", data, 32)[0],
+            "section_header_size": struct.unpack_from(endian + "H", data, 46)[0],
+            "section_count": struct.unpack_from(endian + "H", data, 48)[0],
+            "string_table_index": struct.unpack_from(endian + "H", data, 50)[0],
+            "section_format": endian + "IIIIIIIIII",
+            "symbol_format": endian + "IIIBBH",
+        }
+    raise SystemExit(f"{path} has unsupported ELF class {elf_class}")
 
-    def section_header(index: int):
-        return struct.unpack_from(
-            section_format, data, section_header_offset + index * section_header_size
-        )
 
-    string_header = section_header(string_table_index)
-    section_names = data[
-        string_header[offset_index] : string_header[offset_index] + string_header[size_index]
-    ]
-
-    dynsym = None
-    for index in range(section_count):
-        header = section_header(index)
-        name = section_names[header[name_index] :].split(b"\x00", 1)[0]
+def find_dynsym(data: bytes, layout: dict, path: Path):
+    string_header = section_header(data, layout, layout["string_table_index"])
+    names = slice_bytes(data, string_header[OFFSET], string_header[SIZE])
+    named = None
+    typed = None
+    for index in range(layout["section_count"]):
+        header = section_header(data, layout, index)
+        name = names[header[NAME] :].split(b"\x00", 1)[0]
         if name == b".dynsym":
-            dynsym = header
+            named = header
             break
-        if dynsym is None and header[type_index] == 11:
-            dynsym = header
+        if typed is None and header[TYPE] == 11:
+            typed = header
+    dynsym = named or typed
     if dynsym is None:
         raise SystemExit(f"{path} has no .dynsym section")
+    return dynsym
 
-    string_table_header = section_header(dynsym[link_index])
-    string_table = data[
-        string_table_header[offset_index] : string_table_header[offset_index]
-        + string_table_header[size_index]
-    ]
-    entry_size = dynsym[entry_size_index] or struct.calcsize(symbol_format)
+
+def names_from_dynsym(data: bytes, layout: dict, dynsym) -> set[str]:
+    strings = section_header(data, layout, dynsym[LINK])
+    string_table = slice_bytes(data, strings[OFFSET], strings[SIZE])
+    entry_size = dynsym[ENTRY_SIZE] or struct.calcsize(layout["symbol_format"])
     names: set[str] = set()
-    for index in range(dynsym[size_index] // entry_size):
-        symbol = struct.unpack_from(symbol_format, data, dynsym[offset_index] + index * entry_size)
-        name = string_table[symbol[symbol_name_index] :].split(b"\x00", 1)[0].decode("utf-8", "replace")
+    for index in range(dynsym[SIZE] // entry_size):
+        offset = dynsym[OFFSET] + index * entry_size
+        symbol = struct.unpack_from(layout["symbol_format"], data, offset)
+        raw = string_table[symbol[0] :].split(b"\x00", 1)[0]
+        name = raw.decode("utf-8", "replace")
         if name:
             names.add(name)
     return names
+
+
+def section_header(data: bytes, layout: dict, index: int):
+    offset = layout["section_header_offset"] + index * layout["section_header_size"]
+    return struct.unpack_from(layout["section_format"], data, offset)
+
+
+def slice_bytes(data: bytes, offset: int, size: int) -> bytes:
+    return data[offset : offset + size]
 
 
 if __name__ == "__main__":

--- a/bindings/dotnet/scripts/check_elf_dynsym_exports.py
+++ b/bindings/dotnet/scripts/check_elf_dynsym_exports.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+
+import struct
+import sys
+from pathlib import Path
+
+
+def main() -> None:
+    if len(sys.argv) == 2 and sys.argv[1] == "--self-test":
+        run_self_test()
+        return
+    if len(sys.argv) < 3:
+        raise SystemExit("usage: check_elf_dynsym_exports.py <elf> <symbol>...")
+
+    path = Path(sys.argv[1])
+    needed = sys.argv[2:]
+    missing = missing_exports(path, needed)
+    if missing:
+        raise SystemExit(f"{path} is missing dynsym exports: {', '.join(missing)}")
+
+
+def run_self_test() -> None:
+    import tempfile
+
+    symbol = "turso_sync_database_new"
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".so") as handle:
+        handle.write(elf64_with_dynsym(symbol))
+        path = Path(handle.name)
+    try:
+        if missing_exports(path, [symbol]):
+            raise SystemExit("self-test failed: expected export was not found")
+        if not missing_exports(path, ["turso_sync_database_missing"]):
+            raise SystemExit("self-test failed: missing export was not reported")
+    finally:
+        path.unlink()
+
+
+def missing_exports(path: Path, needed: list[str]) -> list[str]:
+    names = dynsym_names(path)
+    return [symbol for symbol in needed if symbol not in names]
+
+
+def elf64_with_dynsym(symbol: str) -> bytes:
+    shstrtab = b"\0.shstrtab\0.dynstr\0.dynsym\0"
+    dynstr = b"\0" + symbol.encode("ascii") + b"\0"
+    dynsym = bytes(24) + struct.pack("<IBBHQQ", 1, 0x12, 0, 1, 0x1000, 8)
+
+    shstrtab_offset = 64
+    dynstr_offset = shstrtab_offset + len(shstrtab)
+    dynsym_offset = dynstr_offset + len(dynstr)
+    dynsym_pad = (8 - (dynsym_offset % 8)) % 8
+    dynsym_offset += dynsym_pad
+    section_offset = dynsym_offset + len(dynsym)
+
+    def section(name: int, typ: int, flags: int, offset: int, size: int, link: int, info: int, align: int, entsize: int) -> bytes:
+        return struct.pack("<IIQQQQIIQQ", name, typ, flags, 0, offset, size, link, info, align, entsize)
+
+    sections = (
+        bytes(64)
+        + section(1, 3, 0, shstrtab_offset, len(shstrtab), 0, 0, 1, 0)
+        + section(11, 3, 2, dynstr_offset, len(dynstr), 0, 0, 1, 0)
+        + section(19, 11, 2, dynsym_offset, len(dynsym), 2, 1, 8, 24)
+    )
+    header = bytes([0x7F, 0x45, 0x4C, 0x46, 2, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0])
+    header += struct.pack("<HHIQQQIHHHHHH", 3, 62, 1, 0, 0, section_offset, 0, 64, 0, 0, 64, 4, 1)
+    return header + shstrtab + dynstr + (b"\0" * dynsym_pad) + dynsym + sections
+
+
+def dynsym_names(path: Path) -> set[str]:
+    data = path.read_bytes()
+    if data[:4] != b"\x7fELF":
+        raise SystemExit(f"{path} is not an ELF file")
+
+    little = data[5] == 1
+    endian = "<" if little else ">"
+    elf_class = data[4]
+    if elf_class == 2:
+        section_header_offset = struct.unpack_from(endian + "Q", data, 40)[0]
+        section_header_size, section_count, string_table_index = struct.unpack_from(
+            endian + "HHH", data, 58
+        )
+        section_format = endian + "IIQQQQIIQQ"
+        name_index, type_index, offset_index, size_index, link_index, entry_size_index = (
+            0,
+            1,
+            4,
+            5,
+            6,
+            9,
+        )
+        symbol_format = endian + "IBBHQQ"
+        symbol_name_index = 0
+    elif elf_class == 1:
+        section_header_offset = struct.unpack_from(endian + "I", data, 32)[0]
+        section_header_size, section_count, string_table_index = struct.unpack_from(
+            endian + "HHH", data, 46
+        )
+        section_format = endian + "IIIIIIIIII"
+        name_index, type_index, offset_index, size_index, link_index, entry_size_index = (
+            0,
+            1,
+            4,
+            5,
+            6,
+            9,
+        )
+        symbol_format = endian + "IIIBBH"
+        symbol_name_index = 0
+    else:
+        raise SystemExit(f"{path} has unsupported ELF class {elf_class}")
+
+    def section_header(index: int):
+        return struct.unpack_from(
+            section_format, data, section_header_offset + index * section_header_size
+        )
+
+    string_header = section_header(string_table_index)
+    section_names = data[
+        string_header[offset_index] : string_header[offset_index] + string_header[size_index]
+    ]
+
+    dynsym = None
+    for index in range(section_count):
+        header = section_header(index)
+        name = section_names[header[name_index] :].split(b"\x00", 1)[0]
+        if name == b".dynsym":
+            dynsym = header
+            break
+        if dynsym is None and header[type_index] == 11:
+            dynsym = header
+    if dynsym is None:
+        raise SystemExit(f"{path} has no .dynsym section")
+
+    string_table_header = section_header(dynsym[link_index])
+    string_table = data[
+        string_table_header[offset_index] : string_table_header[offset_index]
+        + string_table_header[size_index]
+    ]
+    entry_size = dynsym[entry_size_index] or struct.calcsize(symbol_format)
+    names: set[str] = set()
+    for index in range(dynsym[size_index] // entry_size):
+        symbol = struct.unpack_from(symbol_format, data, dynsym[offset_index] + index * entry_size)
+        name = string_table[symbol[symbol_name_index] :].split(b"\x00", 1)[0].decode("utf-8", "replace")
+        if name:
+            names.add(name)
+    return names
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

`validate-android-package` in [run 34318638325](https://github.com/tursodatabase/turso/actions/runs/34318638325) (`v0.8.0-pre.10`) failed with:

```
Android package asset does not export turso_sync_database_new
```

The packaged `android-arm64` `libturso_sdk_kit.so` already exports that symbol. The check grepped NDK `llvm-readelf --dyn-syms --wide` output for an end-of-line match, which is not a stable listing of ELF dynsym names.

## Change

- Add `bindings/dotnet/scripts/check_elf_dynsym_exports.py` to read ELF `.dynsym` names directly.
- Use it on the packed Native `android-arm64` library and on the Android consumer APK `.so`.
- Prefer the `android-arm64` signed APK when locating the consumer package.

iOS package validation already passed on that run; NuGet publish was skipped because Android validation failed.