### PR TITLE
github: skip the apt install when jq and coreutils are present

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -104,7 +104,13 @@ jobs:
           fetch-depth: 0
 
       - name: Ensure tooling (jq, coreutils)
+        shell: bash
         run: |
+          set -euo pipefail
+          if command -v jq >/dev/null && command -v sha256sum >/dev/null; then
+            echo "jq and coreutils are already installed."
+            exit 0
+          fi
           sudo apt-get update
           sudo apt-get install -y jq coreutils
 


### PR DESCRIPTION
# NOTICE:

## Description

The `Publish Go driver` job started with `sudo apt-get update` and then installed `jq` and `coreutils`. The step now looks for the two tools first. When one tool is missing, the step uses apt.

## Motivation and context

`apt-get update` exits with code 100 when a third-party repository on the `ubuntu-latest` image serves a bad index. The Google Chrome repository did this. Every push to main failed on the first step of the publish job, before it did any work. Examples: [run 34385031859](https://github.com/tursodatabase/turso/actions/runs/34385031859/job/102581510722) and [run 34382687838](https://github.com/tursodatabase/turso/actions/runs/34382687838/job/102573560280).

Both tools are already on the image. `coreutils` is an essential Ubuntu package. `publish-cli-npm.yml`, `release.yml` and `codspeed.yml` all use `jq` there with no install step.

The apt fallback stays, so the step cannot get worse.

## Description of AI Usage

Claude Code read the failed log, found the cause, wrote the change, and opened this PR. A human asked for the fix and reviews it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K8bREhsYQcArd993BPT8UA