### PR TITLE
make is_nonnull return false for the array operators @> and &&

### DIFF
--- a/core/translate/optimizer/mod.rs
+++ b/core/translate/optimizer/mod.rs
@@ -3405,6 +3405,7 @@ impl Optimizable for ast::Expr {
             } => lhs.is_nonnull(tables) && start.is_nonnull(tables) && end.is_nonnull(tables),
             Expr::Binary(_, ast::Operator::Modulus | ast::Operator::Divide, _) => false, // 1 % 0, 1 / 0
             Expr::Binary(_, ast::Operator::ArrowRight | ast::Operator::ArrowRightShift, _) => false, // JSON path may be absent, yielding NULL
+            Expr::Binary(_, ast::Operator::ArrayContains | ast::Operator::ArrayOverlap, _) => false,
             Expr::Binary(expr, _, expr1) => expr.is_nonnull(tables) && expr1.is_nonnull(tables),
             Expr::Case {
                 when_then_pairs,

--- a/sqlite/conformance/sqlite-sqltests/index-seek-null-key.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/index-seek-null-key.sqltest
@@ -54,3 +54,19 @@ test json-arrow-existing-path-still-uses-index {
 expect {
     1
 }
+
+@setup schema
+test array-contains-non-array-operand-select {
+    SELECT count(*) FROM t3 WHERE c > (5 @> 5);
+}
+expect {
+    0
+}
+
+@setup schema
+test array-overlap-non-array-operand-select {
+    SELECT count(*) FROM t3 WHERE c > (5 && 5);
+}
+expect {
+    0
+}

--- a/sqlite/conformance/sqlite-sqltests/index-seek-null-key.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/index-seek-null-key.sqltest
@@ -55,6 +55,8 @@ expect {
     1
 }
 
+@skip-if sqlite "@> isn't supported by sqlite"
+@requires custom_types "array operators require --experimental-custom-types"
 @setup schema
 test array-contains-non-array-operand-select {
     SELECT count(*) FROM t3 WHERE c > (5 @> 5);
@@ -63,6 +65,8 @@ expect {
     0
 }
 
+@skip-if sqlite "&& isn't supported by sqlite"
+@requires custom_types "array operators require --experimental-custom-types"
 @setup schema
 test array-overlap-non-array-operand-select {
     SELECT count(*) FROM t3 WHERE c > (5 && 5);


### PR DESCRIPTION
Compliments [#8691 ](https://github.com/tursodatabase/turso/pull/8691) on unblocking [#8688](https://github.com/tursodatabase/turso/pull/8688) 

Make is_nonnull return false for the array operators @> and && to prevent the bug that would be otherwise caused by running the fast count track for non-nullable columns.