### PR TITLE
core: upgrade tantivy to 0.26.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6329,9 +6329,9 @@ dependencies = [
 
 [[package]]
 name = "tantivy"
-version = "0.26.1"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edde6a10743fff00a4e1a8c9ef020bf5f3cbad301b7d2d39f2b07f123c4eac07"
+checksum = "861facfabd71044968f364837f9a083b56464ba5a59079f88706ee5c451ca069"
 dependencies = [
  "aho-corasick",
  "arc-swap",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -85,7 +85,7 @@ libc = { version = "0.2.172" }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 libloading = "0.8.6"
-tantivy = { version = "0.26.0", optional = true }
+tantivy = { version = "0.26.2", optional = true }
 crc32fast = { version = "1", optional = true }
 
 [dependencies]


### PR DESCRIPTION
Upgrade the optional FTS dependency to Tantivy 0.26.2, retaining the existing semver requirement style. Update the lockfile from 0.26.1 to 0.26.2; no transitive dependencies or Rust source changes are needed.

Validation on Rust 1.88.0:
- `cargo fmt --all`
- `git diff --check`
- `cargo test --locked -p core_tester --test integration_tests --features fts index_method::` — 117 passed, 0 failed.

The full workspace test suite was not run.