### PR TITLE
whopper: add FTS-backed Elle models that read through the full-text index

### DIFF
--- a/.github/workflows/elle.yml
+++ b/.github/workflows/elle.yml
@@ -36,7 +36,7 @@ jobs:
       fail-fast: false
       matrix:
         mode: [default, mvcc, mvcc-passive]
-        elle_model: [list-append, rw-register]
+        elle_model: [list-append, rw-register, fts-list-append, fts-rw-register]
     steps:
       - uses: actions/checkout@v4
 
@@ -131,7 +131,12 @@ jobs:
           if [ "${{ matrix.mode }}" != "default" ]; then
             CONSISTENCY_FLAG="--consistency-models snapshot-isolation"
           fi
-          java -jar "$ELLE_JAR" --model ${{ matrix.elle_model }} $CONSISTENCY_FLAG --verbose --directory elle-results elle-history.edn
+          # The FTS-backed models write the same history shape as the plain
+          # ones; only the whopper side differs, so elle-cli checks them with
+          # the plain model name.
+          ELLE_CLI_MODEL="${{ matrix.elle_model }}"
+          ELLE_CLI_MODEL="${ELLE_CLI_MODEL#fts-}"
+          java -jar "$ELLE_JAR" --model "$ELLE_CLI_MODEL" $CONSISTENCY_FLAG --verbose --directory elle-results elle-history.edn
 
       - name: Upload Elle results
         uses: actions/upload-artifact@v4

--- a/testing/concurrent-simulator/README.md
+++ b/testing/concurrent-simulator/README.md
@@ -59,3 +59,48 @@ java -jar /tmp/elle-cli/target/elle-cli-0.1.9-standalone.jar \
     --directory elle-results \
     elle-history.edn
 ```
+
+### Elle models
+
+`--elle` selects the model. `list-append` and `rw-register` read and write
+rows of one table by primary key. `fts-list-append` and `fts-rw-register`
+run the same transaction mix, but the table also has a `body` column with a
+full-text index on it, every write rewrites `body`, and every read is a
+`fts_match` query on the key token instead of a primary-key lookup:
+
+| Model             | Table            | Write                                      | Read                                                       |
+|-------------------|------------------|--------------------------------------------|------------------------------------------------------------|
+| `list-append`     | `elle_lists`     | append value to `vals`                     | `SELECT vals ... WHERE key = 'k1'`                         |
+| `rw-register`     | `elle_rw`        | set `val`                                  | `SELECT val ... WHERE key = 'k1'`                          |
+| `fts-list-append` | `elle_fts_lists` | append to `vals`, append `v<value>` to `body` | `SELECT vals ... WHERE fts_match(body, 'k1')`           |
+| `fts-rw-register` | `elle_fts_rw`    | set `val`, set `body` to `k1 v<value>`     | `SELECT val ... WHERE fts_match(body, 'k1')`               |
+
+So for the `fts-` models the full-text index is the register Elle checks:
+which row a read sees is decided by the index's view of the transaction's
+snapshot, including the writer's own uncommitted documents and tombstones.
+The history has the same shape as the plain model, so elle-cli still runs
+with `--model list-append` or `--model rw-register`. The `fts-` models also
+run a low-weight `OPTIMIZE INDEX` outside transactions so segment merges
+happen while the history is recorded, and a read that returns more than one
+row for a key token fails the run on the spot.
+
+```shell
+SEED=1 ./target/debug/turso_whopper \
+    --elle fts-rw-register \
+    --elle-output elle-history.edn \
+    --max-steps 100000 \
+    --enable-mvcc
+
+java -jar /tmp/elle-cli/target/elle-cli-0.1.9-standalone.jar \
+    --model rw-register \
+    --consistency-models snapshot-isolation \
+    --verbose \
+    --directory elle-results \
+    elle-history.edn
+```
+
+The `fts-` models fail more transactions than the plain ones under the
+default allocation-fault injection, because an FTS write allocates far more
+than a primary-key upsert and so is hit by more injected `OutOfMemory`
+errors. Those show up as `:fail` events, which Elle handles; pass
+`--allocation-fault-probability 0` for a history with fewer of them.

--- a/testing/concurrent-simulator/chaotic_elle.rs
+++ b/testing/concurrent-simulator/chaotic_elle.rs
@@ -29,7 +29,7 @@ use rand::Rng;
 use rand_chacha::ChaCha8Rng;
 
 use crate::elle::{ELLE_LIST_APPEND_KEY_COUNT, ELLE_RW_REGISTER_KEY_COUNT, elle_key_name};
-use crate::operations::{OpResult, Operation, TxMode};
+use crate::operations::{ElleLookup, OpResult, Operation, TxMode};
 
 /// A chaotic workload instance (one per fiber, drives a single transaction).
 ///
@@ -65,6 +65,7 @@ enum PlannedOp {
 struct ChaoticElleWorkload {
     table_name: String,
     model: ElleModelKind,
+    lookup: ElleLookup,
     enable_mvcc: bool,
     ops: Vec<PlannedOp>,
     index: usize,
@@ -74,12 +75,14 @@ impl ChaoticElleWorkload {
     fn new(
         table_name: String,
         model: ElleModelKind,
+        lookup: ElleLookup,
         enable_mvcc: bool,
         ops: Vec<PlannedOp>,
     ) -> Self {
         Self {
             table_name,
             model,
+            lookup,
             enable_mvcc,
             ops,
             index: 0,
@@ -99,10 +102,12 @@ impl ChaoticElleWorkload {
                 ElleModelKind::ListAppend => Operation::ElleRead {
                     table_name: self.table_name.clone(),
                     key: key.clone(),
+                    lookup: self.lookup,
                 },
                 ElleModelKind::RwRegister => Operation::ElleRwRead {
                     table_name: self.table_name.clone(),
                     key: key.clone(),
+                    lookup: self.lookup,
                 },
             },
             PlannedOp::Write { key, value } => match self.model {
@@ -110,11 +115,13 @@ impl ChaoticElleWorkload {
                     table_name: self.table_name.clone(),
                     key: key.clone(),
                     value: *value,
+                    lookup: self.lookup,
                 },
                 ElleModelKind::RwRegister => Operation::ElleRwWrite {
                     table_name: self.table_name.clone(),
                     key: key.clone(),
                     value: *value,
+                    lookup: self.lookup,
                 },
             },
             PlannedOp::Commit => Operation::Commit,
@@ -149,6 +156,7 @@ impl ChaoticWorkload for ChaoticElleWorkload {
 pub struct ChaoticElleProfile {
     table_name: String,
     model: ElleModelKind,
+    lookup: ElleLookup,
     value_counter: Arc<AtomicI64>,
     enable_mvcc: bool,
 }
@@ -160,9 +168,26 @@ impl ChaoticElleProfile {
         value_counter: Arc<AtomicI64>,
         enable_mvcc: bool,
     ) -> Self {
+        Self::with_lookup(
+            table_name,
+            model,
+            ElleLookup::PrimaryKey,
+            value_counter,
+            enable_mvcc,
+        )
+    }
+
+    pub fn with_lookup(
+        table_name: String,
+        model: ElleModelKind,
+        lookup: ElleLookup,
+        value_counter: Arc<AtomicI64>,
+        enable_mvcc: bool,
+    ) -> Self {
         Self {
             table_name,
             model,
+            lookup,
             value_counter,
             enable_mvcc,
         }
@@ -357,6 +382,7 @@ impl ChaoticWorkloadProfile for ChaoticElleProfile {
         Box::new(ChaoticElleWorkload::new(
             self.table_name.clone(),
             self.model,
+            self.lookup,
             self.enable_mvcc,
             ops,
         ))

--- a/testing/concurrent-simulator/elle.rs
+++ b/testing/concurrent-simulator/elle.rs
@@ -219,6 +219,11 @@ pub fn elle_key_name(index: usize) -> String {
     format!("k{index}")
 }
 
+/// Name of the full-text index on an FTS-backed Elle table.
+pub fn elle_fts_index_name(table_name: &str) -> String {
+    format!("{table_name}_idx")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/testing/concurrent-simulator/main.rs
+++ b/testing/concurrent-simulator/main.rs
@@ -11,6 +11,7 @@ use turso_whopper::{
     StepResult, Whopper, WhopperOpts,
     chaotic_btree::BtreeRebalanceProfile,
     chaotic_elle::{ChaoticElleProfile, ChaoticWorkloadProfile, ElleModelKind},
+    operations::ElleLookup,
     properties::*,
     workloads::*,
 };
@@ -22,6 +23,10 @@ enum ElleModel {
     ListAppend,
     /// Rw-register model: transactions write and read single values
     RwRegister,
+    /// List-append model where every read goes through a full-text index
+    FtsListAppend,
+    /// Rw-register model where every read goes through a full-text index
+    FtsRwRegister,
 }
 
 #[derive(Parser)]
@@ -368,56 +373,35 @@ fn build_workloads_and_properties(args: &Args) -> BuildArtifacts {
     if let Some(elle_model) = args.elle {
         let elle_counter = Arc::new(std::sync::atomic::AtomicI64::new(1));
 
-        let (table_name, create_sql) = match elle_model {
-            ElleModel::ListAppend => (
-                "elle_lists",
-                "CREATE TABLE IF NOT EXISTS elle_lists (key TEXT PRIMARY KEY, vals TEXT DEFAULT '')",
-            ),
-            ElleModel::RwRegister => (
-                "elle_rw",
-                "CREATE TABLE IF NOT EXISTS elle_rw (key TEXT PRIMARY KEY, val INTEGER)",
-            ),
+        let model_kind = match elle_model {
+            ElleModel::ListAppend | ElleModel::FtsListAppend => ElleModelKind::ListAppend,
+            ElleModel::RwRegister | ElleModel::FtsRwRegister => ElleModelKind::RwRegister,
         };
 
-        let model_kind = match elle_model {
-            ElleModel::ListAppend => ElleModelKind::ListAppend,
-            ElleModel::RwRegister => ElleModelKind::RwRegister,
+        let lookup = match elle_model {
+            ElleModel::ListAppend | ElleModel::RwRegister => ElleLookup::PrimaryKey,
+            ElleModel::FtsListAppend | ElleModel::FtsRwRegister => ElleLookup::FtsIndex,
         };
+
+        let (table_name, create_sql) = lookup.schema(model_kind);
 
         let chaotic: Vec<(f64, &'static str, Box<dyn ChaoticWorkloadProfile>)> = vec![(
             0.3,
             "chaotic-elle",
-            Box::new(ChaoticElleProfile::new(
-                table_name.to_string(),
+            Box::new(ChaoticElleProfile::with_lookup(
+                table_name.clone(),
                 model_kind,
+                lookup,
                 elle_counter.clone(),
                 args.enable_mvcc,
             )),
         )];
 
-        let w: Vec<(u32, Box<dyn Workload>)> = match elle_model {
-            ElleModel::ListAppend => vec![
-                (40, Box::new(ElleAppendWorkload::with_counter(elle_counter))),
-                (30, Box::new(ElleReadWorkload)),
-                (30, Box::new(BeginWorkload)),
-                (15, Box::new(CommitWorkload)),
-                (5, Box::new(RollbackWorkload)),
-            ],
-            ElleModel::RwRegister => vec![
-                (
-                    40,
-                    Box::new(ElleRwWriteWorkload::with_counter(elle_counter)),
-                ),
-                (30, Box::new(ElleRwReadWorkload)),
-                (30, Box::new(BeginWorkload)),
-                (15, Box::new(CommitWorkload)),
-                (5, Box::new(RollbackWorkload)),
-            ],
-        };
+        let w = elle_workloads(model_kind, lookup, &table_name, elle_counter);
 
         let output_path = PathBuf::from(&args.elle_output);
         let p: Vec<Box<dyn Property>> = vec![Box::new(ElleHistoryRecorder::new(output_path))];
-        let et = vec![(table_name.to_string(), create_sql.to_string())];
+        let et = vec![(table_name, create_sql)];
 
         (w, p, et, chaotic)
     } else if is_btree_rebalance_mode(&args.mode) {

--- a/testing/concurrent-simulator/operations.rs
+++ b/testing/concurrent-simulator/operations.rs
@@ -3,6 +3,8 @@
 use rand_chacha::ChaCha8Rng;
 use turso_core::{LimboError, Value};
 
+use crate::chaotic_elle::ElleModelKind;
+use crate::elle::elle_fts_index_name;
 use crate::{SamplesContainer, SequenceParams, SimulatorFiber, SimulatorState, Stats};
 
 /// Maximum number of keys to remember per table
@@ -44,6 +46,114 @@ impl TxMode {
     pub fn is_deferred(self) -> bool {
         matches!(self, TxMode::Default | TxMode::Deferred)
     }
+}
+
+/// How an Elle model finds its rows: by primary key, or through a full-text
+/// index on a `body` column. Every Elle operation asks this for its SQL, so
+/// with `FtsIndex` each read is an `fts_match` query and the history Elle
+/// checks is the one the FTS index produced.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ElleLookup {
+    PrimaryKey,
+    FtsIndex,
+}
+
+impl ElleLookup {
+    pub fn is_fts(self) -> bool {
+        matches!(self, ElleLookup::FtsIndex)
+    }
+
+    /// Table name and bootstrap SQL of one model. The FTS schemas create the
+    /// table and its index in one step so the index never registers as an
+    /// Elle table of its own.
+    pub fn schema(self, model: ElleModelKind) -> (String, String) {
+        let table_name = match (self, model) {
+            (ElleLookup::PrimaryKey, ElleModelKind::ListAppend) => "elle_lists",
+            (ElleLookup::PrimaryKey, ElleModelKind::RwRegister) => "elle_rw",
+            (ElleLookup::FtsIndex, ElleModelKind::ListAppend) => "elle_fts_lists",
+            (ElleLookup::FtsIndex, ElleModelKind::RwRegister) => "elle_fts_rw",
+        };
+        let value_column = match model {
+            ElleModelKind::ListAppend => "vals TEXT DEFAULT ''",
+            ElleModelKind::RwRegister => "val INTEGER",
+        };
+        let create_sql = match self {
+            ElleLookup::PrimaryKey => format!(
+                "CREATE TABLE IF NOT EXISTS {table_name} (key TEXT PRIMARY KEY, {value_column})"
+            ),
+            ElleLookup::FtsIndex => {
+                let index_name = elle_fts_index_name(table_name);
+                format!(
+                    "CREATE TABLE IF NOT EXISTS {table_name} (key TEXT PRIMARY KEY, {value_column}, body TEXT); \
+                     CREATE INDEX IF NOT EXISTS {index_name} ON {table_name} USING fts(body)"
+                )
+            }
+        };
+        (table_name.to_string(), create_sql)
+    }
+
+    pub fn append_sql(self, table_name: &str, key: &str, value: i64) -> String {
+        let append_vals =
+            format!("vals = CASE WHEN vals = '' THEN '{value}' ELSE vals || ',' || '{value}' END");
+        match self {
+            ElleLookup::PrimaryKey => format!(
+                "INSERT INTO {table_name} (key, vals) VALUES ('{key}', '{value}') \
+                 ON CONFLICT(key) DO UPDATE SET {append_vals}"
+            ),
+            ElleLookup::FtsIndex => {
+                let token = fts_value_token(value);
+                format!(
+                    "INSERT INTO {table_name} (key, vals, body) VALUES ('{key}', '{value}', '{key} {token}') \
+                     ON CONFLICT(key) DO UPDATE SET {append_vals}, body = body || ' {token}'"
+                )
+            }
+        }
+    }
+
+    pub fn read_sql(self, table_name: &str, key: &str) -> String {
+        format!(
+            "SELECT vals FROM {table_name} WHERE {}",
+            self.row_filter(key)
+        )
+    }
+
+    pub fn rw_write_sql(self, table_name: &str, key: &str, value: i64) -> String {
+        match self {
+            ElleLookup::PrimaryKey => format!(
+                "INSERT INTO {table_name} (key, val) VALUES ('{key}', {value}) \
+                 ON CONFLICT(key) DO UPDATE SET val = {value}"
+            ),
+            ElleLookup::FtsIndex => {
+                let token = fts_value_token(value);
+                format!(
+                    "INSERT INTO {table_name} (key, val, body) VALUES ('{key}', {value}, '{key} {token}') \
+                     ON CONFLICT(key) DO UPDATE SET val = {value}, body = '{key} {token}'"
+                )
+            }
+        }
+    }
+
+    pub fn rw_read_sql(self, table_name: &str, key: &str) -> String {
+        format!(
+            "SELECT val FROM {table_name} WHERE {}",
+            self.row_filter(key)
+        )
+    }
+
+    fn row_filter(self, key: &str) -> String {
+        match self {
+            ElleLookup::PrimaryKey => format!("key = '{key}'"),
+            ElleLookup::FtsIndex => format!("fts_match(body, '{key}')"),
+        }
+    }
+}
+
+/// The token that marks one written value inside an FTS-backed row's
+/// `body`. Every write changes the body, so the index replaces the
+/// document inside the writing transaction instead of indexing each key
+/// only once.
+fn fts_value_token(value: i64) -> String {
+    format!("v{value}")
 }
 
 /// An operation that can be executed on the database.
@@ -101,17 +211,27 @@ pub enum Operation {
         table_name: String,
         key: String,
         value: i64,
+        lookup: ElleLookup,
     },
     /// Read an Elle list by key
-    ElleRead { table_name: String, key: String },
+    ElleRead {
+        table_name: String,
+        key: String,
+        lookup: ElleLookup,
+    },
     /// Write a single value to an Elle rw-register key
     ElleRwWrite {
         table_name: String,
         key: String,
         value: i64,
+        lookup: ElleLookup,
     },
     /// Read a single value from an Elle rw-register key
-    ElleRwRead { table_name: String, key: String },
+    ElleRwRead {
+        table_name: String,
+        key: String,
+        lookup: ElleLookup,
+    },
     /// Create a sequence with specified parameters
     CreateSequence {
         seq_name: String,
@@ -218,33 +338,24 @@ impl Operation {
                 table_name,
                 key,
                 value,
-            } => {
-                // Append value to vals column. If empty, set to value. Otherwise append with comma.
-                // Uses CASE to handle empty string vs non-empty string
-                format!(
-                    "INSERT INTO {table_name} (key, vals) VALUES ('{key}', '{value}') \
-                     ON CONFLICT(key) DO UPDATE SET vals = CASE \
-                       WHEN vals = '' THEN '{value}' \
-                       ELSE vals || ',' || '{value}' \
-                     END"
-                )
-            }
-            Operation::ElleRead { table_name, key } => {
-                format!("SELECT vals FROM {table_name} WHERE key = '{key}'")
-            }
+                lookup,
+            } => lookup.append_sql(table_name, key, *value),
+            Operation::ElleRead {
+                table_name,
+                key,
+                lookup,
+            } => lookup.read_sql(table_name, key),
             Operation::ElleRwWrite {
                 table_name,
                 key,
                 value,
-            } => {
-                format!(
-                    "INSERT INTO {table_name} (key, val) VALUES ('{key}', {value}) \
-                     ON CONFLICT(key) DO UPDATE SET val = {value}"
-                )
-            }
-            Operation::ElleRwRead { table_name, key } => {
-                format!("SELECT val FROM {table_name} WHERE key = '{key}'")
-            }
+                lookup,
+            } => lookup.rw_write_sql(table_name, key, *value),
+            Operation::ElleRwRead {
+                table_name,
+                key,
+                lookup,
+            } => lookup.rw_read_sql(table_name, key),
             Operation::CreateSequence {
                 seq_name,
                 start,

--- a/testing/concurrent-simulator/properties.rs
+++ b/testing/concurrent-simulator/properties.rs
@@ -1,6 +1,6 @@
 //! Property-based validation for simulation.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::PathBuf;
 
 use anyhow::{anyhow, bail};
@@ -402,10 +402,11 @@ struct PendingAutoCommit {
 /// Property that records Elle history for transactional consistency checking.
 /// Events are buffered in memory and sorted by index before writing to file.
 pub struct ElleHistoryRecorder {
-    /// Pending transactions per fiber: fiber_id -> PendingTxn
-    pending_txns: HashMap<usize, PendingTxn>,
+    /// Pending transactions per fiber: fiber_id -> PendingTxn.
+    /// Ordered by fiber so `finalize` writes the same history for the same seed.
+    pending_txns: BTreeMap<usize, PendingTxn>,
     /// Pending auto-commit operations per fiber: fiber_id -> PendingAutoCommit
-    pending_auto_commits: HashMap<usize, PendingAutoCommit>,
+    pending_auto_commits: BTreeMap<usize, PendingAutoCommit>,
     /// Buffered events to be sorted and written at the end
     events: Vec<BufferedElleEvent>,
     /// Counter for generating unique event indices
@@ -417,8 +418,8 @@ pub struct ElleHistoryRecorder {
 impl ElleHistoryRecorder {
     pub fn new(output_path: PathBuf) -> Self {
         Self {
-            pending_txns: HashMap::new(),
-            pending_auto_commits: HashMap::new(),
+            pending_txns: BTreeMap::new(),
+            pending_auto_commits: BTreeMap::new(),
             events: Vec::new(),
             index_counter: 0,
             output_path,
@@ -653,6 +654,7 @@ impl Property for ElleHistoryRecorder {
         op: &Operation,
         result: &OpResult,
     ) -> anyhow::Result<()> {
+        reject_ambiguous_fts_read(op, result)?;
         match op {
             Operation::Begin { .. } => {
                 // If Begin failed, clean up pending txn
@@ -828,8 +830,7 @@ impl Property for ElleHistoryRecorder {
 
     fn finalize(&mut self) -> anyhow::Result<()> {
         // Emit :info events for any pending transactions (incomplete)
-        let pending_txns: Vec<_> = self.pending_txns.drain().collect();
-        for (fiber_id, pending) in pending_txns {
+        for (fiber_id, pending) in std::mem::take(&mut self.pending_txns) {
             let Some(invoke_index) = pending.invoke_index else {
                 continue;
             };
@@ -859,8 +860,7 @@ impl Property for ElleHistoryRecorder {
         }
 
         // Emit :info events for any pending auto-commit operations (incomplete)
-        let pending_auto: Vec<_> = self.pending_auto_commits.drain().collect();
-        for (fiber_id, pending) in pending_auto {
+        for (fiber_id, pending) in std::mem::take(&mut self.pending_auto_commits) {
             self.add_event(
                 pending.invoke_index,
                 ElleEventType::Invoke,
@@ -881,6 +881,28 @@ impl Property for ElleHistoryRecorder {
         self.export()?;
         Ok(())
     }
+}
+
+/// An FTS-backed Elle read asks the index for one key token, so at most one
+/// row can come back. Two rows mean the index returned the same key twice,
+/// for example a replaced document whose tombstone the snapshot missed.
+fn reject_ambiguous_fts_read(op: &Operation, result: &OpResult) -> anyhow::Result<()> {
+    let (key, lookup) = match op {
+        Operation::ElleRead { key, lookup, .. } | Operation::ElleRwRead { key, lookup, .. } => {
+            (key, *lookup)
+        }
+        _ => return Ok(()),
+    };
+    let Ok(rows) = result else {
+        return Ok(());
+    };
+    if lookup.is_fts() && rows.len() > 1 {
+        anyhow::bail!(
+            "FTS-backed Elle read of key {key} returned {} rows, expected at most one: {rows:?}",
+            rows.len()
+        );
+    }
+    Ok(())
 }
 
 /// Parse the read result from query rows.
@@ -2133,6 +2155,7 @@ impl Property for SequenceCorrectnessProperty {
 #[allow(clippy::items_after_test_module)]
 mod tests {
     use super::*;
+    use crate::operations::ElleLookup;
 
     fn test_output_path(label: &str) -> PathBuf {
         std::env::temp_dir().join(format!(
@@ -2240,6 +2263,7 @@ mod tests {
                     table_name: "elle_lists".to_string(),
                     key: "k".to_string(),
                     value: 5,
+                    lookup: ElleLookup::PrimaryKey,
                 },
                 &Ok(vec![]),
             )
@@ -2257,6 +2281,60 @@ mod tests {
     }
 
     #[test]
+    fn elle_history_records_an_fts_read_like_a_primary_key_read() {
+        let mut recorder = ElleHistoryRecorder::new(test_output_path("fts-read"));
+        let read = Operation::ElleRwRead {
+            table_name: "elle_fts_rw".to_string(),
+            key: "k1".to_string(),
+            lookup: ElleLookup::FtsIndex,
+        };
+
+        recorder.init_op(0, 2, None, 40, &read).unwrap();
+        recorder
+            .finish_op(
+                0,
+                2,
+                None,
+                40,
+                41,
+                &read,
+                &Ok(vec![vec![Value::from_i64(42)]]),
+            )
+            .unwrap();
+
+        assert_eq!(recorder.events.len(), 2);
+        assert_eq!(recorder.events[0].ops[0].to_edn(), "[:r \"k1\" nil]");
+        assert_eq!(recorder.events[1].ops[0].to_edn(), "[:r \"k1\" 42]");
+    }
+
+    #[test]
+    fn elle_history_rejects_an_fts_read_that_returns_two_rows() {
+        let mut recorder = ElleHistoryRecorder::new(test_output_path("fts-two-rows"));
+        let two_rows = Ok(vec![vec![Value::from_i64(1)], vec![Value::from_i64(2)]]);
+
+        let primary_key_read = Operation::ElleRwRead {
+            table_name: "elle_rw".to_string(),
+            key: "k1".to_string(),
+            lookup: ElleLookup::PrimaryKey,
+        };
+        recorder.init_op(0, 2, None, 40, &primary_key_read).unwrap();
+        recorder
+            .finish_op(0, 2, None, 40, 41, &primary_key_read, &two_rows)
+            .unwrap();
+
+        let fts_read = Operation::ElleRead {
+            table_name: "elle_fts_lists".to_string(),
+            key: "k1".to_string(),
+            lookup: ElleLookup::FtsIndex,
+        };
+        recorder.init_op(0, 2, None, 42, &fts_read).unwrap();
+        let err = recorder
+            .finish_op(0, 2, None, 42, 43, &fts_read, &two_rows)
+            .expect_err("two rows for one key token must fail the property");
+        assert!(err.to_string().contains("returned 2 rows"), "{err}");
+    }
+
+    #[test]
     fn elle_history_abort_fiber_marks_pending_autocommit_as_info() {
         let mut recorder = ElleHistoryRecorder::new(test_output_path("abort-autocommit"));
 
@@ -2270,6 +2348,7 @@ mod tests {
                     table_name: "elle_rw".to_string(),
                     key: "k".to_string(),
                     value: 9,
+                    lookup: ElleLookup::PrimaryKey,
                 },
             )
             .unwrap();

--- a/testing/concurrent-simulator/regression_tests_cross_platform.rs
+++ b/testing/concurrent-simulator/regression_tests_cross_platform.rs
@@ -335,8 +335,185 @@ fn test_fts_workloads_use_the_index_and_replay_with_the_seed() {
         token: "alpha".to_string(),
     }
     .sql();
+    let opcodes = explain_opcodes(&conn, &io, &differential);
+    assert!(
+        opcodes.iter().any(|opcode| opcode == "IndexMethodQuery"),
+        "the FTS differential is not planned through the index method: {opcodes:?}"
+    );
+}
+
+/// The FTS-backed Elle models make the full-text index the register that
+/// Elle checks: every read must be planned through the index (the scalar
+/// `fts_match` fallback would only re-check the base table), the history
+/// must contain writes and answered reads in the shape elle-cli expects,
+/// and a same-seed run must replay to an identical history.
+#[test]
+fn test_fts_elle_models_read_through_the_index_and_replay_with_the_seed() {
+    use std::sync::atomic::AtomicI64;
+    use turso_whopper::chaotic_elle::{ChaoticElleProfile, ChaoticWorkloadProfile, ElleModelKind};
+    use turso_whopper::operations::{ElleLookup, Operation};
+    use turso_whopper::properties::{ElleHistoryRecorder, Property};
+    use turso_whopper::workloads::elle_workloads;
+    use turso_whopper::{Stats, Whopper, WhopperOpts};
+
+    fn run(model: ElleModelKind, seed: u64) -> (Stats, String) {
+        let (table_name, create_sql) = ElleLookup::FtsIndex.schema(model);
+        let counter = Arc::new(AtomicI64::new(1));
+        let workloads = elle_workloads(model, ElleLookup::FtsIndex, &table_name, counter.clone());
+        let history_path = std::env::temp_dir().join(format!(
+            "whopper-fts-elle-{}-{}-{model:?}.edn",
+            std::process::id(),
+            seed
+        ));
+        let properties: Vec<Box<dyn Property>> =
+            vec![Box::new(ElleHistoryRecorder::new(history_path.clone()))];
+        let chaotic_profiles: Vec<(f64, &'static str, Box<dyn ChaoticWorkloadProfile>)> = vec![(
+            0.3,
+            "chaotic-elle",
+            Box::new(ChaoticElleProfile::with_lookup(
+                table_name.clone(),
+                model,
+                ElleLookup::FtsIndex,
+                counter,
+                true,
+            )),
+        )];
+        let opts = WhopperOpts {
+            seed: Some(seed),
+            max_connections: 3,
+            max_steps: 3_000,
+            enable_mvcc: true,
+            elle_tables: vec![(table_name, create_sql)],
+            workloads,
+            properties,
+            chaotic_profiles,
+            ..WhopperOpts::default()
+        };
+        let mut whopper = Whopper::new(opts).expect("create whopper");
+        whopper
+            .run()
+            .expect("FTS Elle workloads must not violate a property");
+        let history = std::fs::read_to_string(&history_path).expect("history file");
+        let _ = std::fs::remove_file(&history_path);
+        (whopper.stats.clone(), history)
+    }
+
+    fn has_answered_read(history: &str) -> bool {
+        history
+            .lines()
+            .filter(|line| line.contains(":type :ok"))
+            .flat_map(|line| line.split("[:r \"k").skip(1))
+            .any(|rest| {
+                rest.split_once("\" ")
+                    .is_some_and(|(_, value)| !value.starts_with("nil"))
+            })
+    }
+
+    let models = [
+        (ElleModelKind::RwRegister, "[:w \"k"),
+        (ElleModelKind::ListAppend, "[:append \"k"),
+    ];
+    for (model, write_marker) in &models {
+        let (stats, history) = run(*model, 0xE11E);
+        assert!(
+            stats.elle_writes > 0 && stats.elle_reads > 0,
+            "{model:?}: {stats:?}"
+        );
+        assert!(
+            history.contains(write_marker),
+            "{model:?} history has no writes"
+        );
+        assert!(
+            history.contains("[:r \"k"),
+            "{model:?} history has no reads"
+        );
+        assert!(
+            has_answered_read(&history),
+            "{model:?}: no read through the FTS index returned a value:\n{history}"
+        );
+        let (_, replayed) = run(*model, 0xE11E);
+        assert!(
+            replayed == history,
+            "{model:?}: same-seed runs produced different histories"
+        );
+    }
+
+    let io = Arc::new(SimulatorIO::new(
+        false,
+        ChaCha8Rng::seed_from_u64(7),
+        IOFaultConfig {
+            cosmic_ray_probability: 0.0,
+        },
+    ));
+    let db_path = format!("test-fts-elle-plan-{}.db", std::process::id());
+    let db = Database::open_file_with_flags(
+        io.clone(),
+        &db_path,
+        OpenFlags::default(),
+        DatabaseOpts::new().with_index_method(true),
+        None,
+        Arc::new(SqliteDialect),
+    )
+    .expect("open db");
+    let conn = db.connect().expect("connect");
+    let (rw_table, rw_schema) = ElleLookup::FtsIndex.schema(ElleModelKind::RwRegister);
+    let (list_table, list_schema) = ElleLookup::FtsIndex.schema(ElleModelKind::ListAppend);
+    for create_sql in [rw_schema, list_schema] {
+        conn.execute(&create_sql)
+            .expect("bootstrap FTS Elle schema");
+    }
+    let reads = [
+        Operation::ElleRwRead {
+            table_name: rw_table.clone(),
+            key: "k1".to_string(),
+            lookup: ElleLookup::FtsIndex,
+        },
+        Operation::ElleRead {
+            table_name: list_table,
+            key: "k1".to_string(),
+            lookup: ElleLookup::FtsIndex,
+        },
+    ];
+    for read in &reads {
+        let opcodes = explain_opcodes(&conn, &io, &read.sql());
+        assert!(
+            opcodes.iter().any(|opcode| opcode == "IndexMethodQuery"),
+            "{read:?} is not planned through the index method: {opcodes:?}"
+        );
+    }
+
+    for value in [7, 8] {
+        let write = Operation::ElleRwWrite {
+            table_name: rw_table.clone(),
+            key: "k1".to_string(),
+            value,
+            lookup: ElleLookup::FtsIndex,
+        };
+        conn.execute(write.sql())
+            .expect("write through the FTS Elle table");
+    }
+    let mut stmt = conn.prepare(reads[0].sql()).expect("prepare FTS read");
+    let mut values = Vec::new();
+    loop {
+        match stmt.step().expect("step FTS read") {
+            turso_core::StepResult::Row => {
+                values.push(stmt.row().expect("row").get::<i64>(0).expect("val"));
+            }
+            turso_core::StepResult::IO => io.step().expect("io step"),
+            turso_core::StepResult::Done => break,
+            other => panic!("unexpected step result {other:?}"),
+        }
+    }
+    assert_eq!(
+        values,
+        vec![8],
+        "the key token must find exactly the row's latest value through the index"
+    );
+}
+
+fn explain_opcodes(conn: &Arc<turso_core::Connection>, io: &SimulatorIO, sql: &str) -> Vec<String> {
     let mut stmt = conn
-        .prepare(format!("EXPLAIN {differential}"))
+        .prepare(format!("EXPLAIN {sql}"))
         .expect("prepare explain");
     let mut opcodes = Vec::new();
     loop {
@@ -350,8 +527,5 @@ fn test_fts_workloads_use_the_index_and_replay_with_the_seed() {
             other => panic!("unexpected step result {other:?}"),
         }
     }
-    assert!(
-        opcodes.iter().any(|opcode| opcode == "IndexMethodQuery"),
-        "the FTS differential is not planned through the index method: {opcodes:?}"
-    );
+    opcodes
 }

--- a/testing/concurrent-simulator/workloads.rs
+++ b/testing/concurrent-simulator/workloads.rs
@@ -13,8 +13,11 @@ use sql_generation::{
     },
 };
 
-use crate::elle::{ELLE_LIST_APPEND_KEY_COUNT, ELLE_RW_REGISTER_KEY_COUNT, elle_key_name};
-use crate::operations::{Operation, TxMode};
+use crate::chaotic_elle::ElleModelKind;
+use crate::elle::{
+    ELLE_LIST_APPEND_KEY_COUNT, ELLE_RW_REGISTER_KEY_COUNT, elle_fts_index_name, elle_key_name,
+};
+use crate::operations::{ElleLookup, Operation, TxMode};
 use crate::{FiberState, SimulatorState};
 
 /// Context passed to workloads for generating operations.
@@ -493,6 +496,49 @@ impl Workload for RollbackWorkload {
 // Elle Workloads for Consistency Checking
 // ============================================================================
 
+/// The weighted workload set of one Elle model: writes, reads, and
+/// transaction control. FTS-backed models also get a low-weight
+/// `OPTIMIZE INDEX` so segment merges happen while the history is recorded.
+pub fn elle_workloads(
+    model: ElleModelKind,
+    lookup: ElleLookup,
+    table_name: &str,
+    value_counter: std::sync::Arc<std::sync::atomic::AtomicI64>,
+) -> Vec<(u32, Box<dyn Workload>)> {
+    let (write, read): (Box<dyn Workload>, Box<dyn Workload>) = match model {
+        ElleModelKind::ListAppend => (
+            Box::new(ElleAppendWorkload::with_counter_and_lookup(
+                value_counter,
+                lookup,
+            )),
+            Box::new(ElleReadWorkload { lookup }),
+        ),
+        ElleModelKind::RwRegister => (
+            Box::new(ElleRwWriteWorkload::with_counter_and_lookup(
+                value_counter,
+                lookup,
+            )),
+            Box::new(ElleRwReadWorkload { lookup }),
+        ),
+    };
+    let mut workloads: Vec<(u32, Box<dyn Workload>)> = vec![
+        (40, write),
+        (30, read),
+        (30, Box::new(BeginWorkload)),
+        (15, Box::new(CommitWorkload)),
+        (5, Box::new(RollbackWorkload)),
+    ];
+    if lookup.is_fts() {
+        workloads.push((
+            2,
+            Box::new(ElleFtsOptimizeWorkload {
+                index_name: elle_fts_index_name(table_name),
+            }),
+        ));
+    }
+    workloads
+}
+
 /// Create Elle list table for consistency checking.
 pub struct CreateElleTableWorkload;
 
@@ -511,19 +557,26 @@ impl Workload for CreateElleTableWorkload {
 pub struct ElleAppendWorkload {
     /// Counter for generating unique append values
     pub value_counter: std::sync::Arc<std::sync::atomic::AtomicI64>,
+    pub lookup: ElleLookup,
 }
 
 impl ElleAppendWorkload {
     pub fn new() -> Self {
-        Self {
-            value_counter: std::sync::Arc::new(std::sync::atomic::AtomicI64::new(1)),
-        }
+        Self::with_counter(std::sync::Arc::new(std::sync::atomic::AtomicI64::new(1)))
     }
 
     /// Create with a shared counter (for coordinating with chaotic Elle workloads).
     pub fn with_counter(counter: std::sync::Arc<std::sync::atomic::AtomicI64>) -> Self {
+        Self::with_counter_and_lookup(counter, ElleLookup::PrimaryKey)
+    }
+
+    pub fn with_counter_and_lookup(
+        counter: std::sync::Arc<std::sync::atomic::AtomicI64>,
+        lookup: ElleLookup,
+    ) -> Self {
         Self {
             value_counter: counter,
+            lookup,
         }
     }
 }
@@ -549,12 +602,15 @@ impl Workload for ElleAppendWorkload {
             table_name,
             key,
             value,
+            lookup: self.lookup,
         })
     }
 }
 
 /// Read a random key from an Elle table.
-pub struct ElleReadWorkload;
+pub struct ElleReadWorkload {
+    pub lookup: ElleLookup,
+}
 
 impl Workload for ElleReadWorkload {
     fn generate(&self, ctx: &WorkloadContext, rng: &mut ChaCha8Rng) -> Option<Operation> {
@@ -564,7 +620,11 @@ impl Workload for ElleReadWorkload {
         let table_name = ctx.sim_state.elle_tables.pick(rng)?.0.clone();
         let key = elle_key_name(rng.random_range(0..ELLE_LIST_APPEND_KEY_COUNT));
 
-        Some(Operation::ElleRead { table_name, key })
+        Some(Operation::ElleRead {
+            table_name,
+            key,
+            lookup: self.lookup,
+        })
     }
 }
 
@@ -576,13 +636,22 @@ impl Workload for ElleReadWorkload {
 pub struct ElleRwWriteWorkload {
     /// Counter for generating unique write values
     pub value_counter: std::sync::Arc<std::sync::atomic::AtomicI64>,
+    pub lookup: ElleLookup,
 }
 
 impl ElleRwWriteWorkload {
     /// Create with a shared counter (for coordinating with chaotic Elle workloads).
     pub fn with_counter(counter: std::sync::Arc<std::sync::atomic::AtomicI64>) -> Self {
+        Self::with_counter_and_lookup(counter, ElleLookup::PrimaryKey)
+    }
+
+    pub fn with_counter_and_lookup(
+        counter: std::sync::Arc<std::sync::atomic::AtomicI64>,
+        lookup: ElleLookup,
+    ) -> Self {
         Self {
             value_counter: counter,
+            lookup,
         }
     }
 }
@@ -602,12 +671,15 @@ impl Workload for ElleRwWriteWorkload {
             table_name,
             key,
             value,
+            lookup: self.lookup,
         })
     }
 }
 
 /// Read a random key from an Elle rw-register table.
-pub struct ElleRwReadWorkload;
+pub struct ElleRwReadWorkload {
+    pub lookup: ElleLookup,
+}
 
 impl Workload for ElleRwReadWorkload {
     fn generate(&self, ctx: &WorkloadContext, rng: &mut ChaCha8Rng) -> Option<Operation> {
@@ -617,7 +689,30 @@ impl Workload for ElleRwReadWorkload {
         let table_name = ctx.sim_state.elle_tables.pick(rng)?.0.clone();
         let key = elle_key_name(rng.random_range(0..ELLE_RW_REGISTER_KEY_COUNT));
 
-        Some(Operation::ElleRwRead { table_name, key })
+        Some(Operation::ElleRwRead {
+            table_name,
+            key,
+            lookup: self.lookup,
+        })
+    }
+}
+
+/// Merge the segments of an FTS-backed Elle table's index while the history
+/// is being recorded. Runs only outside transactions: a merge that loses the
+/// per-index lease or a commit conflict then costs nothing in the history,
+/// while inside a transaction it would abort the whole Elle transaction.
+pub struct ElleFtsOptimizeWorkload {
+    pub index_name: String,
+}
+
+impl Workload for ElleFtsOptimizeWorkload {
+    fn generate(&self, ctx: &WorkloadContext, _rng: &mut ChaCha8Rng) -> Option<Operation> {
+        if *ctx.fiber_state != FiberState::Idle {
+            return None;
+        }
+        Some(Operation::Execute {
+            sql: format!("OPTIMIZE INDEX {}", self.index_name),
+        })
     }
 }
 


### PR DESCRIPTION
## Description

Adds two Elle consistency-check models to whopper whose read side goes through a full-text index instead of a primary-key lookup, so the FTS index itself is the register elle-cli checks for snapshot-isolation and serializability anomalies under MVCC.

- `--elle fts-rw-register`: table `elle_fts_rw (key TEXT PRIMARY KEY, val INTEGER, body TEXT)` with `CREATE INDEX elle_fts_rw_idx ON elle_fts_rw USING fts(body)`. Writes upsert `val` and set `body` to `'<key> v<value>'`; reads are `SELECT val FROM elle_fts_rw WHERE fts_match(body, '<key>')`.
- `--elle fts-list-append`: same over `elle_fts_lists (key, vals TEXT DEFAULT '', body TEXT)`, appending `v<value>` to `body` on every append; reads are `SELECT vals ... WHERE fts_match(body, '<key>')`.
- The value token in `body` makes every write replace the indexed document, so the index sees a tombstone plus a new document inside each writing transaction rather than one insert per key.
- An `ElleLookup {PrimaryKey, FtsIndex}` enum on the four existing Elle operations owns the schema and SQL of both lookups. The history recorder, `apply_state_changes`, stats, and the chaotic profile (all seven templates) keep working unchanged, and the EDN shape is identical, so elle-cli still checks these histories with `--model list-append` / `--model rw-register`.
- The recorder fails the run if an FTS read returns more than one row for a key token.
- A weight-2 `OPTIMIZE INDEX` workload runs outside transactions for the FTS models so segment merges happen during the history; in auto-commit a lost merge lease costs nothing in the history (18 `Busy` failures in a 20k-step run, none of them a `:fail` transaction).
- Fixes a pre-existing nondeterminism: `ElleHistoryRecorder::finalize` drained a `HashMap`, so the trailing `:info` events of still-open transactions got indices in hash order and two runs of one seed could produce different histories. The pending maps are `BTreeMap`s now, so they drain in fiber order.
- CI: `.github/workflows/elle.yml` matrix now includes `fts-list-append` and `fts-rw-register` in all three modes (default, mvcc, mvcc-passive); the `fts-` prefix is stripped when invoking elle-cli.
- README documents the new models and how to run them.

Tests: `cargo test -p turso_whopper`, including a new cross-platform regression test that runs both FTS models for a few thousand MVCC steps and asserts the history has writes and answered reads, the read SQL is planned through `IndexMethodQuery`, a key token finds exactly the row's latest value through the index, and a same-seed run replays to an identical history. Two recorder unit tests cover the multi-row rejection and that FTS reads are recorded like primary-key reads.

Manual validation with elle-cli (built from the same revision CI pins):

| History | Mode | Check | Verdict |
|---|---|---|---|
| fts-rw-register, seed 7, 100k steps | mvcc | rw-register / snapshot-isolation | valid |
| fts-list-append, seed 7, 100k steps | mvcc | list-append / snapshot-isolation | valid |
| fts-rw-register, seed 1, 20k steps | default | rw-register / serializable | valid |
| fts-list-append, seed 1, 20k steps | default | list-append / serializable | valid |
| fts-rw-register, seed 1, 20k steps | mvcc-passive, threshold 1024 | rw-register / snapshot-isolation | valid |
| fts-list-append, seed 1, 20k steps | mvcc-passive, threshold 1024 | list-append / snapshot-isolation | valid |

The 100k-step MVCC list-append history contains `G2-item` (write skew) cycles when checked against serializability, which snapshot isolation permits and `BEGIN CONCURRENT` is expected to produce; no other anomaly class appeared. No FTS bug surfaced. The FTS models show more `:fail` transactions than the plain ones under the default 5% allocation-fault injection because an FTS write allocates far more than a primary-key upsert; every extra failure traced to injected `OutOfMemory`.

## Motivation and context

The existing Elle check covered rows found by primary key, so the FTS index never took part in any isolation check even though FTS rows are ordinary MVCC-versioned index rows with their own visibility, tombstone, and merge behavior. With the read side routed through `fts_match`, which row a read sees is decided by the index's view of the transaction's snapshot, including the writer's own uncommitted documents and tombstones, giving a property-based isolation check of FTS under MVCC in CI.

## Description of AI Usage

The change was implemented by Claude Code from a task description that specified the goal, the whopper components involved, and the validation steps. The AI read the simulator and FTS code, chose the operation-field design, wrote the code, tests, workflow, and README changes, ran cargo fmt/clippy/test, ran the simulator for each model and mode, diagnosed the recorder replay nondeterminism, built elle-cli, and ran the analyses above. The committer reviewed the output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XtGvk1Bj49gtS7UH7sBaaX


---
_Generated by [Claude Code](https://claude.ai/code)_