### PR TITLE
core/index_method: give index methods a core-owned backing store handle

### DIFF
--- a/core/index_method/backing_store.rs
+++ b/core/index_method/backing_store.rs
@@ -1,0 +1,506 @@
+use std::collections::VecDeque;
+use std::sync::atomic::Ordering;
+use std::sync::{Arc, Weak};
+
+use crate::{
+    index_method::{btree_root_page, IndexMethodContext, BACKING_BTREE_INDEX_METHOD_NAME},
+    mvcc::{cursor::MvccCursorType, database::MVTableId},
+    return_if_io,
+    schema::{Type, TURSO_INTERNAL_PREFIX},
+    storage::btree::{BTreeCursor, CursorTrait},
+    types::{IOResult, IOResultOr, IndexInfo, KeyInfo},
+    util::quote_identifier,
+    Connection, LimboError, MvCursor, MvStore, Result,
+};
+
+impl IndexMethodContext {
+    /// Find the backing store that is `index`. Returns `None` if the index
+    /// is not in the schema yet.
+    pub fn backing_store(&self, index: &BackingIndex) -> Result<Option<BackingStore>> {
+        BackingStore::lookup(&self.connection()?, self.database().id, index)
+    }
+
+    /// Create the tables of `schema`, then its indexes, in order. An object
+    /// that already exists is skipped.
+    pub fn create_backing_schema(&self, schema: &BackingSchema) -> Result<BackingStoreOp> {
+        let connection = self.connection()?;
+        let database_id = self.database().id;
+        let db_prefix = database_prefix(&connection, database_id);
+        let mut statements = Vec::new();
+        for table in &schema.tables {
+            if !table.exists(&connection, database_id) {
+                statements.push(table.create_statement(&db_prefix));
+            }
+        }
+        for index in &schema.indexes {
+            if !index.exists(&connection, database_id) {
+                statements.push(index.create_statement(&db_prefix));
+            }
+        }
+        Ok(BackingStoreOp::new(&connection, statements))
+    }
+
+    /// Drop the indexes of `schema`, then its tables, in order. Dropping a
+    /// table also drops the indexes on it.
+    pub fn drop_backing_schema(&self, schema: &BackingSchema) -> Result<BackingStoreOp> {
+        let connection = self.connection()?;
+        let database_id = self.database().id;
+        let db_prefix = database_prefix(&connection, database_id);
+        let statements = schema
+            .indexes
+            .iter()
+            .map(|index| index.drop_statement(&db_prefix))
+            .chain(
+                schema
+                    .tables
+                    .iter()
+                    .map(|table| table.drop_statement(&db_prefix)),
+            )
+            .collect::<Vec<_>>();
+        Ok(BackingStoreOp::new(&connection, statements))
+    }
+}
+
+fn database_prefix(connection: &Connection, database_id: usize) -> String {
+    connection
+        .get_database_name_by_index(database_id)
+        .filter(|name| name != "main")
+        .map(|name| format!("{}.", quote_identifier(&name)))
+        .unwrap_or_default()
+}
+
+/// The tables and indexes that an index method owns. Core creates and drops
+/// them as one unit, and gives a `BackingStore` handle for each index.
+#[derive(Debug, Clone, Default)]
+pub struct BackingSchema {
+    pub tables: Vec<BackingTable>,
+    pub indexes: Vec<BackingIndex>,
+}
+
+impl BackingSchema {
+    pub fn new(tables: Vec<BackingTable>, indexes: Vec<BackingIndex>) -> Self {
+        Self { tables, indexes }
+    }
+}
+
+/// A table that core creates for an index method. Its name in the schema
+/// is `__turso_internal_<name>`.
+#[derive(Debug, Clone)]
+pub struct BackingTable {
+    pub name: String,
+    pub columns: Vec<BackingColumn>,
+}
+
+impl BackingTable {
+    pub fn new(name: impl Into<String>, columns: Vec<BackingColumn>) -> Self {
+        Self {
+            name: name.into(),
+            columns,
+        }
+    }
+
+    /// The name of the table in the schema.
+    pub fn table_name(&self) -> String {
+        format!("{TURSO_INTERNAL_PREFIX}{}", self.name)
+    }
+
+    fn exists(&self, connection: &Connection, database_id: usize) -> bool {
+        let table = self.table_name();
+        connection.with_schema(database_id, |schema| {
+            schema.get_btree_table(&table).is_some()
+        })
+    }
+
+    fn create_statement(&self, db_prefix: &str) -> String {
+        let column_definitions = self
+            .columns
+            .iter()
+            .map(|column| {
+                format!(
+                    "{} {} NOT NULL",
+                    quote_identifier(&column.name),
+                    column.column_type
+                )
+            })
+            .collect::<Vec<_>>()
+            .join(", ");
+        format!(
+            "CREATE TABLE IF NOT EXISTS {db_prefix}{} ({column_definitions})",
+            quote_identifier(&self.table_name())
+        )
+    }
+
+    fn drop_statement(&self, db_prefix: &str) -> String {
+        format!(
+            "DROP TABLE IF EXISTS {db_prefix}{}",
+            quote_identifier(&self.table_name())
+        )
+    }
+}
+
+/// A `backing_btree` index that an index method owns. The table is either a
+/// `BackingTable` or any existing table. `columns` are columns of that
+/// table. `keys` is the key layout of the records that the method writes
+/// through the index, which can differ from the declared columns.
+#[derive(Debug, Clone)]
+pub struct BackingIndex {
+    pub table: String,
+    pub name: String,
+    pub columns: Vec<String>,
+    pub keys: Vec<KeyInfo>,
+}
+
+impl BackingIndex {
+    /// An index on a table that core created for the method.
+    pub fn on_backing_table(
+        table: &BackingTable,
+        name: impl Into<String>,
+        columns: Vec<String>,
+        keys: Vec<KeyInfo>,
+    ) -> Self {
+        Self {
+            table: table.table_name(),
+            name: name.into(),
+            columns,
+            keys,
+        }
+    }
+
+    /// An index on any existing table.
+    pub fn on_table(
+        table: impl Into<String>,
+        name: impl Into<String>,
+        columns: Vec<String>,
+        keys: Vec<KeyInfo>,
+    ) -> Self {
+        Self {
+            table: table.into(),
+            name: name.into(),
+            columns,
+            keys,
+        }
+    }
+
+    fn exists(&self, connection: &Connection, database_id: usize) -> bool {
+        connection.with_schema(database_id, |schema| {
+            schema.get_index(&self.table, &self.name).is_some()
+        })
+    }
+
+    fn create_statement(&self, db_prefix: &str) -> String {
+        let column_names = self
+            .columns
+            .iter()
+            .map(|column| quote_identifier(column))
+            .collect::<Vec<_>>()
+            .join(", ");
+        format!(
+            "CREATE INDEX IF NOT EXISTS {db_prefix}{} ON {} \
+             USING {BACKING_BTREE_INDEX_METHOD_NAME} ({column_names})",
+            quote_identifier(&self.name),
+            quote_identifier(&self.table)
+        )
+    }
+
+    fn drop_statement(&self, db_prefix: &str) -> String {
+        format!(
+            "DROP INDEX IF EXISTS {db_prefix}{}",
+            quote_identifier(&self.name)
+        )
+    }
+}
+
+/// A key column of a backing store.
+#[derive(Debug, Clone)]
+pub struct BackingColumn {
+    pub name: String,
+    pub column_type: Type,
+}
+
+impl BackingColumn {
+    pub fn new(name: impl Into<String>, column_type: Type) -> Self {
+        Self {
+            name: name.into(),
+            column_type,
+        }
+    }
+}
+
+/// A key-only B-tree (a B-tree whose rows are only keys, with no separate
+/// row data) that core owns for an index method.
+///
+/// The method writes every row through cursors that this handle opens.
+/// Under MVCC, those rows are versioned rows that belong to the transaction
+/// and the snapshot that resolved the handle. The method never sees a root
+/// page or an MVCC table id.
+pub struct BackingStore {
+    connection: Weak<Connection>,
+    database_id: usize,
+    table_name: String,
+    root_page: i64,
+    index_info: Arc<IndexInfo>,
+    mvcc: Option<BackingStoreMvccBinding>,
+}
+
+struct BackingStoreMvccBinding {
+    mv_store: Arc<MvStore>,
+    tx_id: u64,
+    table_id: MVTableId,
+}
+
+impl std::fmt::Debug for BackingStore {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("BackingStore")
+            .field("database_id", &self.database_id)
+            .field("table_name", &self.table_name)
+            .field("root_page", &self.root_page)
+            .field("mvcc", &self.mvcc.as_ref().map(|binding| binding.table_id))
+            .finish()
+    }
+}
+
+impl BackingStore {
+    pub(crate) fn lookup(
+        connection: &Arc<Connection>,
+        database_id: usize,
+        index: &BackingIndex,
+    ) -> Result<Option<Self>> {
+        let table_name = index.table.clone();
+        let index_name = index.name.clone();
+        let keys = &index.keys;
+        let Some(index) = connection.with_schema(database_id, |schema| {
+            schema.get_index(&table_name, &index_name).cloned()
+        }) else {
+            return Ok(None);
+        };
+        let index_info = Arc::new(IndexInfo::new(
+            keys.iter().cloned(),
+            false,
+            keys.len(),
+            index.unique,
+        )?);
+        let mvcc = match connection.mv_store_for_db(database_id) {
+            None => None,
+            Some(mv_store) => {
+                let tx_id = connection.get_mv_tx_id_for_db(database_id).ok_or_else(|| {
+                    LimboError::InternalError(format!(
+                        "backing store {index_name} resolved without an active MVCC transaction"
+                    ))
+                })?;
+                let snapshot_ts = mv_store.read_snapshot_ts(tx_id);
+                let table_id = if connection.experimental_mvcc_passive_checkpoint_enabled() {
+                    mv_store
+                        .try_get_table_id_from_root_page_at(index.root_page, snapshot_ts)
+                        .ok_or(LimboError::SchemaUpdated)?
+                } else {
+                    mv_store.get_table_id_from_root_page_at(index.root_page, snapshot_ts)
+                };
+                Some(BackingStoreMvccBinding {
+                    mv_store,
+                    tx_id,
+                    table_id,
+                })
+            }
+        };
+        Ok(Some(Self {
+            connection: Arc::downgrade(connection),
+            database_id,
+            table_name,
+            root_page: index.root_page,
+            index_info,
+            mvcc,
+        }))
+    }
+
+    /// Open a cursor over the rows of the store. Under MVCC, the cursor
+    /// reads the snapshot of the transaction and writes versioned rows.
+    pub fn open_cursor(&self) -> Result<Box<dyn CursorTrait>> {
+        let connection = self.connection()?;
+        let pager = connection.get_pager_from_database_index(&self.database_id)?;
+        let mut cursor = BTreeCursor::new(
+            pager,
+            btree_root_page(&connection, self.database_id, self.root_page),
+            self.index_info.num_cols,
+        );
+        cursor.index_info = Some(Arc::clone(&self.index_info));
+        let Some(binding) = &self.mvcc else {
+            return Ok(Box::new(cursor));
+        };
+        Ok(Box::new(MvCursor::new(
+            Arc::clone(&binding.mv_store),
+            &connection,
+            binding.tx_id,
+            self.root_page,
+            MvccCursorType::Index(Arc::clone(&self.index_info)),
+            Box::new(cursor),
+        )?))
+    }
+
+    /// Under MVCC, take the maintenance lease of this store for the
+    /// transaction of the handle. The owner can take it again. If another
+    /// transaction holds it, the result is `Busy`. If the snapshot is older
+    /// than the last publication, the result is `WriteWriteConflict`. In
+    /// WAL mode this does nothing, because the pager write lock already
+    /// serializes writers.
+    pub fn acquire_maintenance_lease(&self) -> Result<()> {
+        let Some(binding) = &self.mvcc else {
+            return Ok(());
+        };
+        binding
+            .mv_store
+            .acquire_index_method_write_lease(binding.tx_id, binding.table_id)
+    }
+
+    pub(crate) fn register_deleter(&self) -> Result<()> {
+        let Some(binding) = &self.mvcc else {
+            return Ok(());
+        };
+        binding
+            .mv_store
+            .register_index_method_deleter(binding.tx_id, binding.table_id)
+    }
+
+    pub(crate) fn check_merge_admissible(&self) -> Result<()> {
+        let Some(binding) = &self.mvcc else {
+            return Ok(());
+        };
+        binding
+            .mv_store
+            .check_index_method_merge_admissible(binding.tx_id, binding.table_id)
+    }
+
+    /// The schema root of the B-tree of the store. The value is negative
+    /// for an MVCC table that was not checkpointed yet.
+    pub fn root_page(&self) -> i64 {
+        self.root_page
+    }
+
+    pub fn table_name(&self) -> &str {
+        &self.table_name
+    }
+
+    fn connection(&self) -> Result<Arc<Connection>> {
+        self.connection.upgrade().ok_or_else(|| {
+            LimboError::InternalError("backing store handle outlived its connection".to_string())
+        })
+    }
+}
+
+/// A create or a drop of a backing store that is in progress. Step it until
+/// it returns `Done`. It gives its I/O to the caller instead of running the
+/// I/O inside the opcode.
+pub struct BackingStoreOp {
+    ddl: Option<NestedDdl>,
+}
+
+impl BackingStoreOp {
+    fn new(connection: &Arc<Connection>, statements: Vec<String>) -> Self {
+        Self {
+            ddl: (!statements.is_empty()).then(|| NestedDdl::new(connection, statements)),
+        }
+    }
+
+    pub fn step(&mut self) -> IOResultOr<()> {
+        let Some(ddl) = self.ddl.as_mut() else {
+            return Ok(IOResult::Done(()));
+        };
+        return_if_io!(ddl.step());
+        self.ddl = None;
+        Ok(IOResult::Done(()))
+    }
+}
+
+impl std::fmt::Debug for BackingStoreOp {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("BackingStoreOp")
+            .field("pending", &self.ddl.is_some())
+            .finish()
+    }
+}
+
+/// Nested DDL statements that run for an index method. They are stepped one
+/// at a time so that their I/O reaches the caller. The connection is nested
+/// only while one statement is stepped or dropped. The nested flag tells the
+/// pager that the `Halt` and the reset of the statement must not finish the
+/// transaction of the parent. The flag must not leak to other statements
+/// that run on this connection while the parent waits at a yield.
+struct NestedDdl {
+    connection: Weak<Connection>,
+    /// SQL that is still to run, in order. Each statement is prepared only
+    /// when its turn comes, because a later statement can depend on schema
+    /// that an earlier one creates (the backing index on the backing table).
+    pending: VecDeque<String>,
+    current: Option<crate::Statement>,
+}
+
+impl NestedDdl {
+    fn new(connection: &Arc<Connection>, statements: impl IntoIterator<Item = String>) -> Self {
+        Self {
+            connection: Arc::downgrade(connection),
+            pending: statements.into_iter().collect(),
+            current: None,
+        }
+    }
+
+    fn step(&mut self) -> IOResultOr<()> {
+        let connection = self.connection.upgrade().ok_or_else(|| {
+            LimboError::InternalError("backing store DDL outlived its connection".into())
+        })?;
+        loop {
+            if self.current.is_none() {
+                let Some(sql) = self.pending.pop_front() else {
+                    return Ok(IOResult::Done(()));
+                };
+                self.current = Some(Self::prepare(&connection, sql)?);
+            }
+            let statement = self.current.as_mut().expect("prepared above");
+            connection.start_nested();
+            let result = statement.run_ignore_rows_nonblock();
+            if !matches!(result, Ok(IOResult::IO(_))) {
+                // Drop a finished or failed statement while the connection
+                // is still nested. The reset of the statement reads
+                // `is_nested_stmt()`.
+                self.current = None;
+            }
+            connection.end_nested();
+            return_if_io!(result);
+        }
+    }
+
+    /// Prepare `sql` as a nested statement. Top-level statements are not
+    /// permitted to use `__turso_internal_` names. No statement
+    /// subtransaction is started, because the transaction of the parent
+    /// statement covers it. A subtransaction here fails with DatabaseBusy.
+    fn prepare(connection: &Arc<Connection>, sql: String) -> Result<crate::Statement> {
+        connection.start_nested();
+        let statement = connection.prepare(sql);
+        connection.end_nested();
+        let statement = statement?;
+        statement
+            .program
+            .prepared
+            .needs_stmt_subtransactions
+            .store(false, Ordering::Relaxed);
+        Ok(statement)
+    }
+}
+
+impl Drop for NestedDdl {
+    fn drop(&mut self) {
+        // A statement that was abandoned in progress (the parent statement
+        // was reset) is dropped while nested, for the same reason as a
+        // finished one.
+        if self.current.is_none() {
+            return;
+        }
+        let Some(connection) = self.connection.upgrade() else {
+            self.current = None;
+            return;
+        };
+        connection.start_nested();
+        self.current = None;
+        connection.end_nested();
+    }
+}

--- a/core/index_method/fts/mod.rs
+++ b/core/index_method/fts/mod.rs
@@ -17,8 +17,9 @@ use crate::sync::{Arc, Weak};
 use crate::types::IOResultOr;
 use crate::{
     index_method::{
-        open_index_cursor, parse_patterns, IndexMethod, IndexMethodAttachment,
-        IndexMethodConfiguration, IndexMethodContext, IndexMethodCursor, IndexMethodDefinition,
+        parse_patterns, BackingColumn, BackingIndex, BackingSchema, BackingStore, BackingStoreOp,
+        BackingTable, IndexMethod, IndexMethodAttachment, IndexMethodConfiguration,
+        IndexMethodContext, IndexMethodCursor, IndexMethodDefinition,
     },
     return_if_io,
     schema::IndexColumn,
@@ -26,13 +27,12 @@ use crate::{
     translate::collate::CollationSeq,
     turso_assert,
     types::{IOResult, KeyInfo, SeekKey, SeekOp, SeekResult},
-    util::quote_identifier,
     vdbe::Register,
     Connection, LimboError, Result, Value,
 };
 use parking_lot::Mutex;
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
-use std::collections::{BTreeSet, VecDeque};
+use std::collections::BTreeSet;
 use std::path::PathBuf;
 use std::{
     cell::RefCell,
@@ -72,6 +72,54 @@ use rows::{
 
 /// Name identifier for the FTS index method, used in `CREATE INDEX ... USING fts`.
 pub const FTS_INDEX_METHOD_NAME: &str = "fts";
+
+/// The schema objects of one FTS index: one internal table and one key-only
+/// index over `(path, chunk_no, bytes)`.
+struct FtsStore {
+    schema: BackingSchema,
+}
+
+impl FtsStore {
+    fn new(index_name: &str) -> Self {
+        let table = BackingTable::new(
+            format!("fts_dir_{index_name}"),
+            vec![
+                BackingColumn::new("path", crate::schema::Type::Text),
+                BackingColumn::new("chunk_no", crate::schema::Type::Integer),
+                BackingColumn::new("bytes", crate::schema::Type::Blob),
+            ],
+        );
+        let index = BackingIndex::on_backing_table(
+            &table,
+            format!("{}_key", table.table_name()),
+            vec![
+                "path".to_string(),
+                "chunk_no".to_string(),
+                "bytes".to_string(),
+            ],
+            vec![key_info(), key_info(), key_info()],
+        );
+        Self {
+            schema: BackingSchema::new(vec![table], vec![index]),
+        }
+    }
+
+    fn index(&self) -> &BackingIndex {
+        &self.schema.indexes[0]
+    }
+
+    fn table_name(&self) -> String {
+        self.schema.tables[0].table_name()
+    }
+}
+
+fn key_info() -> KeyInfo {
+    KeyInfo {
+        collation: CollationSeq::Binary,
+        sort_order: SortOrder::Asc,
+        nulls_order: None,
+    }
+}
 
 /// Memory budget for Tantivy's per-segment writer arena.
 pub const DEFAULT_MEMORY_BUDGET_BYTES: usize = 64 * 1024 * 1024;
@@ -258,15 +306,6 @@ pub fn fts_match(text: &str, query: &str) -> bool {
         }
         false
     })
-}
-
-/// Creates default `KeyInfo` for BTree index columns.
-fn key_info() -> KeyInfo {
-    KeyInfo {
-        sort_order: SortOrder::Asc,
-        collation: CollationSeq::Binary,
-        nulls_order: None,
-    }
 }
 
 /// Parse field weights from a string like "body=2.0,title=1.0"
@@ -777,91 +816,6 @@ impl IndexMethodAttachment for FtsIndexAttachment {
     }
 }
 
-/// Nested DDL statements a cursor is driving for `create` or `destroy`,
-/// stepped cooperatively so their I/O reaches the caller instead of being
-/// pumped inside the opcode. The connection is nested only while one of
-/// them is being stepped or dropped: the flag tells the pager that the
-/// statement's `Halt` and reset must not finalize the parent's
-/// transaction, and it must not leak to other statements stepped on this
-/// connection while the parent is suspended at a yield.
-struct NestedDdl {
-    connection: Weak<Connection>,
-    /// SQL still to run, in order. Each statement is prepared only when
-    /// its turn comes: a later one may depend on schema an earlier one
-    /// creates (the backing index on the backing table).
-    pending: VecDeque<String>,
-    current: Option<crate::Statement>,
-}
-
-impl NestedDdl {
-    fn new(conn: &Arc<Connection>, statements: impl IntoIterator<Item = String>) -> Self {
-        Self {
-            connection: Arc::downgrade(conn),
-            pending: statements.into_iter().collect(),
-            current: None,
-        }
-    }
-
-    /// Prepare `sql` nested: `__turso_internal_` names are refused to
-    /// top-level statements. No statement subtransaction: the parent
-    /// statement's transaction covers it (a subtransaction here would
-    /// fail with DatabaseBusy).
-    fn prepare(conn: &Arc<Connection>, sql: String) -> Result<crate::Statement> {
-        conn.start_nested();
-        let stmt = conn.prepare(sql);
-        conn.end_nested();
-        let stmt = stmt?;
-        stmt.program
-            .prepared
-            .needs_stmt_subtransactions
-            .store(false, Ordering::Relaxed);
-        Ok(stmt)
-    }
-
-    /// Drive the statements to completion in order, handing their I/O to
-    /// the caller; re-enter after each yield until `Done`.
-    fn step(&mut self) -> IOResultOr<()> {
-        let conn = self.connection.upgrade().ok_or_else(|| {
-            LimboError::InternalError("FTS nested DDL outlived its connection".into())
-        })?;
-        loop {
-            if self.current.is_none() {
-                let Some(sql) = self.pending.pop_front() else {
-                    return Ok(IOResult::Done(()));
-                };
-                self.current = Some(Self::prepare(&conn, sql)?);
-            }
-            let stmt = self.current.as_mut().expect("prepared above");
-            conn.start_nested();
-            let result = stmt.run_ignore_rows_nonblock();
-            if !matches!(result, Ok(IOResult::IO(_))) {
-                // Drop a finished (or failed) statement while still
-                // nested: its reset consults `is_nested_stmt()`.
-                self.current = None;
-            }
-            conn.end_nested();
-            return_if_io!(result);
-        }
-    }
-}
-
-impl Drop for NestedDdl {
-    fn drop(&mut self) {
-        // A statement abandoned mid-flight (the parent statement was reset)
-        // is dropped nested for the same reason a finished one is.
-        if self.current.is_none() {
-            return;
-        }
-        let Some(conn) = self.connection.upgrade() else {
-            self.current = None;
-            return;
-        };
-        conn.start_nested();
-        self.current = None;
-        conn.end_nested();
-    }
-}
-
 /// Pattern indices for FTS queries
 const FTS_PATTERN_SCORE: i64 = 0;
 const FTS_PATTERN_COMBINED_ORDERED_LIMIT: i64 = 1;
@@ -1010,7 +964,7 @@ pub struct FtsCursor {
     text_fields: Vec<(IndexColumn, Field)>,
     /// The user-visible index name, for error messages.
     index_name: String,
-    dir_table_name: String,
+    store: FtsStore,
     /// Pre-computed default fields for QueryParser (avoids rebuilding Vec per query)
     default_fields: Vec<Field>,
     /// Pre-computed (Field, boost) pairs for QueryParser (avoids re-iterating per query)
@@ -1023,10 +977,10 @@ pub struct FtsCursor {
     connection: Option<Weak<Connection>>,
     database_id: Option<usize>,
     fts_dir_cursor: Option<Box<dyn CursorTrait>>,
-    /// Backing-store DDL in flight for `create` / `destroy`; `Some` only
-    /// while it is suspended at an I/O yield.
-    pending_ddl: Option<NestedDdl>,
-    btree_root_page: Option<i64>,
+    /// A create or a drop of the backing store that is in progress. It is
+    /// `Some` only while the operation waits at an I/O yield.
+    pending_store_op: Option<BackingStoreOp>,
+    backing: Option<BackingStore>,
 
     control: Option<FtsControlV2>,
     /// The snapshot's visible segment set (descriptors + resident bytes +
@@ -1085,11 +1039,7 @@ pub struct FtsCursor {
 impl FtsCursor {
     /// Creates a new FTS cursor with the given configuration.
     fn new(attachment: &FtsIndexAttachment) -> Self {
-        let dir_table_name = format!(
-            "{}fts_dir_{}",
-            crate::schema::TURSO_INTERNAL_PREFIX,
-            attachment.cfg.index_name
-        );
+        let store = FtsStore::new(&attachment.cfg.index_name);
         let text_fields = attachment.text_fields.clone();
         let default_fields: Vec<Field> = text_fields.iter().map(|(_, f)| *f).collect();
         let field_boosts: Vec<(Field, f32)> = text_fields
@@ -1107,7 +1057,7 @@ impl FtsCursor {
             ngram_window: attachment.ngram_window,
             text_fields,
             index_name: attachment.cfg.index_name.clone(),
-            dir_table_name,
+            store,
             default_fields,
             field_boosts,
             shared: Arc::clone(&attachment.shared),
@@ -1115,8 +1065,8 @@ impl FtsCursor {
             connection: None,
             database_id: None,
             fts_dir_cursor: None,
-            pending_ddl: None,
-            btree_root_page: None,
+            pending_store_op: None,
+            backing: None,
             control: None,
             segments: Vec::new(),
             snapshot_loaded: false,
@@ -1210,54 +1160,13 @@ impl FtsCursor {
         }
     }
 
-    /// Resolve this index's stable MVCC table id, if MVCC is active.
-    fn mvcc_index_id(
-        &self,
-        conn: &Arc<Connection>,
-        database_id: usize,
-    ) -> Result<Option<(Arc<crate::MvStore>, u64, crate::mvcc::database::MVTableId)>> {
-        let Some(mv_store) = conn.mv_store_for_db(database_id) else {
-            return Ok(None);
-        };
-        let tx_id = conn.get_mv_tx_id_for_db(database_id).ok_or_else(|| {
-            LimboError::InternalError(
-                "FTS write opened without an active MVCC transaction".to_string(),
-            )
-        })?;
-        let root_page = self.btree_root_page.ok_or_else(|| {
-            LimboError::InternalError("FTS backing root is not initialized".to_string())
-        })?;
-        let snapshot_ts = mv_store.read_snapshot_ts(tx_id);
-        // A PASSIVE checkpoint can retire this root page under a stale
-        // compiled plan; that is a stale-schema read, not corruption.
-        let index_id = if conn.experimental_mvcc_passive_checkpoint_enabled() {
-            mv_store
-                .try_get_table_id_from_root_page_at(root_page, snapshot_ts)
-                .ok_or(LimboError::SchemaUpdated)?
-        } else {
-            mv_store.get_table_id_from_root_page_at(root_page, snapshot_ts)
-        };
-        Ok(Some((mv_store, tx_id, index_id)))
-    }
-
     /// Under MVCC, take the per-index maintenance lease (the merge mutex)
     /// for this cursor's transaction. Reentrant for the owning transaction;
     /// a no-op in WAL mode, where the pager write lock already serializes.
     /// Only merge/OPTIMIZE and index teardown take this — plain writers
     /// append disjoint rows and run concurrently.
     fn acquire_mvcc_maintenance_lease(&self) -> Result<()> {
-        let conn = self
-            .connection
-            .as_ref()
-            .and_then(Weak::upgrade)
-            .ok_or_else(|| LimboError::InternalError("FTS cursor has no connection".to_string()))?;
-        let database_id = self.database_id.ok_or_else(|| {
-            LimboError::InternalError("FTS database id is not initialized".to_string())
-        })?;
-        let Some((mv_store, tx_id, index_id)) = self.mvcc_index_id(&conn, database_id)? else {
-            return Ok(());
-        };
-        match mv_store.acquire_index_method_write_lease(tx_id, index_id) {
+        match self.backing_handle()?.acquire_maintenance_lease() {
             Ok(()) => {
                 self.shared
                     .stats
@@ -1283,19 +1192,15 @@ impl FtsCursor {
         if self.registered_deleter {
             return Ok(());
         }
-        let conn = self
-            .connection
-            .as_ref()
-            .and_then(Weak::upgrade)
-            .ok_or_else(|| LimboError::InternalError("FTS cursor has no connection".to_string()))?;
-        let database_id = self.database_id.ok_or_else(|| {
-            LimboError::InternalError("FTS database id is not initialized".to_string())
-        })?;
-        if let Some((mv_store, tx_id, index_id)) = self.mvcc_index_id(&conn, database_id)? {
-            mv_store.register_index_method_deleter(tx_id, index_id)?;
-        }
+        self.backing_handle()?.register_deleter()?;
         self.registered_deleter = true;
         Ok(())
+    }
+
+    fn backing_handle(&self) -> Result<&BackingStore> {
+        self.backing
+            .as_ref()
+            .ok_or_else(|| LimboError::InternalError("FTS backing store is not open".to_string()))
     }
 
     /// Open the backing B-tree cursor for the FTS row store.
@@ -1303,26 +1208,15 @@ impl FtsCursor {
         if self.fts_dir_cursor.is_some() {
             return Ok(());
         }
-        // The index stores all 3 columns: (path, chunk_no, bytes) as the key.
-        let index_name = format!("{}_key", self.dir_table_name);
-        let scratch = conn
-            .with_schema(database_id, |schema| {
-                schema.get_index(&self.dir_table_name, &index_name).cloned()
-            })
-            .ok_or_else(|| {
+        let backing =
+            BackingStore::lookup(conn, database_id, self.store.index())?.ok_or_else(|| {
                 LimboError::InternalError(format!(
-                    "index {} for table {} not found",
-                    index_name, self.dir_table_name
+                    "FTS backing store {} not found",
+                    self.store.table_name()
                 ))
             })?;
-        self.btree_root_page = Some(scratch.root_page);
-        self.fts_dir_cursor = Some(open_index_cursor(
-            conn,
-            database_id,
-            &self.dir_table_name,
-            &index_name,
-            [key_info(), key_info(), key_info()],
-        )?);
+        self.fts_dir_cursor = Some(backing.open_cursor()?);
+        self.backing = Some(backing);
         Ok(())
     }
 
@@ -1918,62 +1812,16 @@ impl FtsCursor {
         self.drive_open()
     }
 
-    /// Make sure the backing table and its `backing_btree` index exist,
-    /// creating them on the first `create`. Every later open takes the
-    /// fast path and never prepares a statement.
-    fn ensure_backing_store(
-        &mut self,
-        conn: &Arc<Connection>,
-        database_id: usize,
-    ) -> IOResultOr<()> {
-        if let Some(ddl) = self.pending_ddl.as_mut() {
-            return_if_io!(ddl.step());
-            self.pending_ddl = None;
-            return Ok(IOResult::Done(()));
+    /// Make sure that the backing store exists. The first `create` creates
+    /// it. Every later open finds it in the schema and does not run DDL.
+    fn ensure_backing_store(&mut self, context: &IndexMethodContext) -> IOResultOr<()> {
+        if self.pending_store_op.is_none() {
+            self.pending_store_op = Some(context.create_backing_schema(&self.store.schema)?);
         }
-        let table_name = self.dir_table_name.clone();
-        let index_name = format!("{table_name}_key");
-        let already_exists = conn.with_schema(database_id, |schema| {
-            schema.get_btree_table(&table_name).is_some()
-                && schema.get_index(&table_name, &index_name).is_some()
-        });
-        if already_exists {
-            return Ok(IOResult::Done(()));
-        }
-        let db_prefix = conn
-            .get_database_name_by_index(database_id)
-            .filter(|name| name != "main")
-            .map(|name| format!("{}.", quote_identifier(&name)))
-            .unwrap_or_default();
-        let table_ident = quote_identifier(&table_name);
-        let create_table_sql = format!(
-            "CREATE TABLE IF NOT EXISTS {db_prefix}{table_ident} \
-             (path TEXT NOT NULL, chunk_no INTEGER NOT NULL, bytes BLOB NOT NULL)"
-        );
-        // backing_btree stores all columns in the index B-tree, without
-        // rowid indirection, so cursors work on the exact key structure.
-        let create_index_sql = format!(
-            "CREATE INDEX IF NOT EXISTS {db_prefix}{index_ident} ON {table_ident} \
-             USING {method} (path, chunk_no, bytes)",
-            index_ident = quote_identifier(&index_name),
-            method = super::BACKING_BTREE_INDEX_METHOD_NAME,
-        );
-        // The store is a table plus its index, so two DDL statements run
-        // here, once per CREATE INDEX, nested inside the parent statement
-        // and stepped cooperatively (see [`NestedDdl`]). A helper that
-        // creates a backing B-tree without going through SQL would replace
-        // both.
-        self.drive_nested_ddl(NestedDdl::new(conn, [create_table_sql, create_index_sql]))
-    }
-
-    /// Step freshly prepared nested DDL; park it on the cursor if it
-    /// yields so the next entry resumes it.
-    fn drive_nested_ddl(&mut self, mut ddl: NestedDdl) -> IOResultOr<()> {
-        let result = ddl.step();
-        if matches!(result, Ok(IOResult::IO(_))) {
-            self.pending_ddl = Some(ddl);
-        }
-        result
+        let op = self.pending_store_op.as_mut().expect("set above");
+        return_if_io!(op.step());
+        self.pending_store_op = None;
+        Ok(IOResult::Done(()))
     }
 
     /// Mint a fresh on-disk index incarnation. Drawn from the IO's random
@@ -1984,7 +1832,7 @@ impl FtsCursor {
     /// (connection-less unit tests) a process-local counter keeps values
     /// distinct.
     fn mint_index_incarnation(&self) -> u64 {
-        let root = self.btree_root_page.unwrap_or_default() as u64;
+        let root = self.backing.as_ref().map_or(0, BackingStore::root_page) as u64;
         let entropy = self
             .io_random_u64()
             .unwrap_or_else(|| NEXT_FTS_INDEX_INCARNATION.fetch_add(1, Ordering::Relaxed));
@@ -2351,20 +2199,14 @@ impl FtsCursor {
             }
             Err(err) => return Err(err),
         }
-        if let Some((mv_store, tx_id, index_id)) = self.mvcc_index_id(
-            &conn,
-            self.database_id
-                .ok_or_else(|| LimboError::InternalError("FTS database id not set".into()))?,
-        )? {
-            match mv_store.check_index_method_merge_admissible(tx_id, index_id) {
-                Ok(()) => {}
-                Err(LimboError::Busy | LimboError::WriteWriteConflict) => {
-                    tracing::debug!("FTS auto-merge: deleter overlap, skipping");
-                    self.auto_merge_pending = false;
-                    return Ok(IOResult::Done(()));
-                }
-                Err(err) => return Err(err),
+        match self.backing_handle()?.check_merge_admissible() {
+            Ok(()) => {}
+            Err(LimboError::Busy | LimboError::WriteWriteConflict) => {
+                tracing::debug!("FTS auto-merge: deleter overlap, skipping");
+                self.auto_merge_pending = false;
+                return Ok(IOResult::Done(()));
             }
+            Err(err) => return Err(err),
         }
         // Tiered candidacy: rewrite the small tier and tombstone-heavy
         // segments, never a big clean segment on every trigger.
@@ -2499,6 +2341,7 @@ impl FtsCursor {
         self.control = None;
         self.invalidate_snapshot_view();
         self.fts_dir_cursor = None;
+        self.backing = None;
         self.current_hits.clear();
         self.streaming_hits = None;
         self.hit_pos = 0;
@@ -2697,19 +2540,11 @@ pub struct FtsBackingRowWiper {
 #[cfg(feature = "test_helper")]
 impl FtsBackingRowWiper {
     pub fn new(conn: &Arc<Connection>, database_id: usize, index_name: &str) -> Result<Self> {
-        let dir_table_name = format!(
-            "{}fts_dir_{}",
-            crate::schema::TURSO_INTERNAL_PREFIX,
-            index_name
-        );
-        let key_index_name = format!("{dir_table_name}_key");
-        let cursor = open_index_cursor(
-            conn,
-            database_id,
-            &dir_table_name,
-            &key_index_name,
-            [key_info(), key_info(), key_info()],
-        )?;
+        let cursor = BackingStore::lookup(conn, database_id, FtsStore::new(index_name).index())?
+            .ok_or_else(|| {
+                LimboError::InternalError(format!("FTS backing store for {index_name} not found"))
+            })?
+            .open_cursor()?;
         Ok(Self {
             cursor,
             // Every path is a prefix match for the empty string.
@@ -2737,19 +2572,11 @@ pub struct FtsBackingRowDumper {
 #[cfg(feature = "test_helper")]
 impl FtsBackingRowDumper {
     pub fn new(conn: &Arc<Connection>, database_id: usize, index_name: &str) -> Result<Self> {
-        let dir_table_name = format!(
-            "{}fts_dir_{}",
-            crate::schema::TURSO_INTERNAL_PREFIX,
-            index_name
-        );
-        let key_index_name = format!("{dir_table_name}_key");
-        let cursor = open_index_cursor(
-            conn,
-            database_id,
-            &dir_table_name,
-            &key_index_name,
-            [key_info(), key_info(), key_info()],
-        )?;
+        let cursor = BackingStore::lookup(conn, database_id, FtsStore::new(index_name).index())?
+            .ok_or_else(|| {
+                LimboError::InternalError(format!("FTS backing store for {index_name} not found"))
+            })?
+            .open_cursor()?;
         Ok(Self {
             cursor,
             started: false,
@@ -2816,7 +2643,7 @@ impl IndexMethodCursor for FtsCursor {
             return_if_io!(self.drive_publish());
             return Ok(IOResult::Done(()));
         }
-        return_if_io!(self.ensure_backing_store(&conn, database_id));
+        return_if_io!(self.ensure_backing_store(context));
         self.open_cursor(&conn, database_id)?;
         self.claim_writer_slot()?;
         let control = FtsControlV2::new(self.mint_index_incarnation());
@@ -2845,16 +2672,15 @@ impl IndexMethodCursor for FtsCursor {
         let database_id = context.database().id;
         self.database_id = Some(database_id);
         self.connection = Some(Arc::downgrade(&conn));
-        if let Some(ddl) = self.pending_ddl.as_mut() {
-            // Resuming the DROP TABLE below after an I/O yield.
-            return_if_io!(ddl.step());
-            self.pending_ddl = None;
+        if let Some(op) = self.pending_store_op.as_mut() {
+            return_if_io!(op.step());
+            self.pending_store_op = None;
             self.state = FtsState::Init;
             return Ok(IOResult::Done(()));
         }
         tracing::debug!(
             "FTS destroy: dropping internal storage {}",
-            self.dir_table_name
+            self.store.table_name()
         );
 
         // Teardown retires every row, like a merge: serialize with
@@ -2871,23 +2697,16 @@ impl IndexMethodCursor for FtsCursor {
         self.snapshot_loaded = false;
         self.invalidate_snapshot_view();
         self.fts_dir_cursor = None;
+        self.backing = None;
         self.control = None;
         *self.shared.segment_bytes.lock() = SegmentByteCache::default();
         *self.shared.searchers.lock() = SearcherCache::default();
 
-        // Drop the internal storage table; the backing_btree index is
-        // dropped automatically with it. Nested inside the parent DROP
-        // INDEX statement and stepped cooperatively (see [`NestedDdl`]).
-        let db_prefix = conn
-            .get_database_name_by_index(database_id)
-            .filter(|name| name != "main")
-            .map(|name| format!("{}.", quote_identifier(&name)))
-            .unwrap_or_default();
-        let drop_table_sql = format!(
-            "DROP TABLE IF EXISTS {db_prefix}{}",
-            quote_identifier(&self.dir_table_name)
-        );
-        return_if_io!(self.drive_nested_ddl(NestedDdl::new(&conn, [drop_table_sql])));
+        let mut op = context.drop_backing_schema(&self.store.schema)?;
+        if let IOResult::IO(io) = op.step()? {
+            self.pending_store_op = Some(op);
+            return Ok(IOResult::IO(io));
+        }
 
         self.state = FtsState::Init;
         Ok(IOResult::Done(()))
@@ -2919,7 +2738,7 @@ impl IndexMethodCursor for FtsCursor {
         if matches!(self.state, FtsState::Ready) {
             return Ok(IOResult::Done(()));
         }
-        return_if_io!(self.ensure_backing_store(&conn, database_id));
+        return_if_io!(self.ensure_backing_store(context));
         if !self.snapshot_loaded {
             self.probe_only = true;
         }
@@ -3444,7 +3263,7 @@ impl IndexMethodCursor for FtsCursor {
         }
 
         if !matches!(self.state, FtsState::Ready) {
-            return_if_io!(self.ensure_backing_store(&conn, database_id));
+            return_if_io!(self.ensure_backing_store(context));
             self.opening_for_write = true;
             let result = self.drive_open();
             if !matches!(result, Ok(IOResult::IO(_))) {
@@ -3477,9 +3296,7 @@ impl IndexMethodCursor for FtsCursor {
         // Belt and braces: re-verify no deleter overlapped between lease
         // acquisition and here (the lease blocks new deleters, so this can
         // only fail if the acquire raced an in-flight registration).
-        if let Some((mv_store, tx_id, index_id)) = self.mvcc_index_id(&conn, database_id)? {
-            mv_store.check_index_method_merge_admissible(tx_id, index_id)?;
-        }
+        self.backing_handle()?.check_merge_admissible()?;
 
         // OPTIMIZE is the explicit "compact now" command: it merges every
         // visible segment, with no tier exemptions.

--- a/core/index_method/mod.rs
+++ b/core/index_method/mod.rs
@@ -14,15 +14,20 @@ use crate::{
         journal_mode::JournalMode,
     },
     translate::emitter::TransactionMode,
-    types::{IOResult, IndexInfo, KeyInfo},
+    types::IOResult,
     vdbe::Register,
     Connection, LimboError, MvCursor, Result, Value,
 };
 
 pub mod backing_btree;
+pub mod backing_store;
 #[cfg(all(feature = "fts", not(target_family = "wasm")))]
 pub mod fts;
 pub mod toy_vector_sparse_ivf;
+
+pub use backing_store::{
+    BackingColumn, BackingIndex, BackingSchema, BackingStore, BackingStoreOp, BackingTable,
+};
 
 pub const BACKING_BTREE_INDEX_METHOD_NAME: &str = "backing_btree";
 pub const TOY_VECTOR_SPARSE_IVF_INDEX_METHOD_NAME: &str = "toy_vector_sparse_ivf";
@@ -377,19 +382,6 @@ impl IndexMethodContext {
     pub fn open_table_cursor(&self, table: &str) -> Result<Box<dyn CursorTrait>> {
         open_table_cursor(&self.connection()?, self.database.id, table)
     }
-
-    pub fn open_index_cursor<I, E>(
-        &self,
-        table: &str,
-        index: &str,
-        keys: I,
-    ) -> Result<Box<dyn CursorTrait>>
-    where
-        I: IntoIterator<Item = KeyInfo, IntoIter = E>,
-        E: ExactSizeIterator<Item = KeyInfo>,
-    {
-        open_index_cursor(&self.connection()?, self.database.id, table, index, keys)
-    }
 }
 
 #[cfg(any(test, injected_yields))]
@@ -723,44 +715,6 @@ pub(crate) fn open_table_cursor(
         root_page,
         cursor,
         MvccCursorType::Table,
-    )
-}
-
-/// Helper method to open an index cursor in an index method implementation.
-pub(crate) fn open_index_cursor<I, E>(
-    connection: &Arc<Connection>,
-    database_id: usize,
-    table: &str,
-    index: &str,
-    keys: I,
-) -> Result<Box<dyn CursorTrait>>
-where
-    I: IntoIterator<Item = KeyInfo, IntoIter = E>,
-    E: ExactSizeIterator<Item = KeyInfo>,
-{
-    let pager = connection.get_pager_from_database_index(&database_id)?;
-    let Some(scratch) = connection.with_schema(database_id, |schema| {
-        schema.get_index(table, index).cloned()
-    }) else {
-        return Err(LimboError::InternalError(format!(
-            "index {index} for table {table} not found",
-        )));
-    };
-    let keys = keys.into_iter();
-    let num_cols = keys.len();
-    let index_info = Arc::new(IndexInfo::new(keys, false, num_cols, scratch.unique)?);
-    let mut cursor = BTreeCursor::new(
-        pager,
-        btree_root_page(connection, database_id, scratch.root_page),
-        num_cols,
-    );
-    cursor.index_info = Some(index_info.clone());
-    promote_to_mvcc_cursor(
-        connection,
-        database_id,
-        scratch.root_page,
-        Box::new(cursor),
-        MvccCursorType::Index(index_info),
     )
 }
 

--- a/core/index_method/toy_vector_sparse_ivf.rs
+++ b/core/index_method/toy_vector_sparse_ivf.rs
@@ -1,18 +1,14 @@
-use std::{
-    collections::{BTreeSet, HashSet, VecDeque},
-    sync::atomic::Ordering,
-};
+use std::collections::{BTreeSet, HashSet, VecDeque};
 
 use crate::types::IOResultOr;
 use turso_parser::ast::{self, SortOrder};
 
 use crate::numeric::Numeric;
-use crate::util::quote_identifier;
 use crate::{
     index_method::{
-        parse_patterns, IndexMethod, IndexMethodAttachment, IndexMethodConfiguration,
-        IndexMethodContext, IndexMethodCursor, IndexMethodDefinition,
-        BACKING_BTREE_INDEX_METHOD_NAME, TOY_VECTOR_SPARSE_IVF_INDEX_METHOD_NAME,
+        parse_patterns, BackingIndex, BackingSchema, BackingStoreOp, IndexMethod,
+        IndexMethodAttachment, IndexMethodConfiguration, IndexMethodContext, IndexMethodCursor,
+        IndexMethodDefinition, TOY_VECTOR_SPARSE_IVF_INDEX_METHOD_NAME,
     },
     return_if_io,
     storage::btree::{BTreeKey, CursorTrait},
@@ -307,11 +303,11 @@ pub struct VectorSparseInvertedIndexMethodCursor {
     delta: f64,
     scan_portion: f64,
     scan_order: ScanOrder,
-    inverted_index_btree: String,
+    schema: BackingSchema,
     inverted_index_cursor: Option<Box<dyn CursorTrait>>,
-    stats_btree: String,
     stats_cursor: Option<Box<dyn CursorTrait>>,
     main_btree: Option<Box<dyn CursorTrait>>,
+    pending_store_ops: VecDeque<BackingStoreOp>,
     insert_state: VectorSparseInvertedIndexInsertState,
     delete_state: VectorSparseInvertedIndexDeleteState,
     search_state: VectorSparseInvertedIndexSearchState,
@@ -359,8 +355,30 @@ impl IndexMethodAttachment for VectorSparseInvertedIndexMethodAttachment {
 
 impl VectorSparseInvertedIndexMethodCursor {
     pub fn new(configuration: IndexMethodConfiguration) -> Self {
-        let inverted_index_btree = format!("{}_inverted_index", configuration.index_name);
-        let stats_btree = format!("{}_stats", configuration.index_name);
+        let columns = configuration
+            .columns
+            .iter()
+            .map(|column| column.name.clone())
+            .collect::<Vec<_>>();
+        let schema = BackingSchema::new(
+            Vec::new(),
+            vec![
+                BackingIndex::on_table(
+                    &configuration.table_name,
+                    format!("{}_inverted_index", configuration.index_name),
+                    columns.clone(),
+                    // component, length, rowid
+                    vec![key_info(), key_info(), key_info()],
+                ),
+                BackingIndex::on_table(
+                    &configuration.table_name,
+                    format!("{}_stats", configuration.index_name),
+                    columns,
+                    // component
+                    vec![key_info()],
+                ),
+            ],
+        );
         let delta = match configuration.parameters.get("delta") {
             Some(&Value::Numeric(Numeric::Float(delta))) => f64::from(delta),
             _ => 0.0,
@@ -383,17 +401,43 @@ impl VectorSparseInvertedIndexMethodCursor {
             delta,
             scan_portion,
             scan_order,
-            inverted_index_btree,
+            schema,
             inverted_index_cursor: None,
-            stats_btree,
             stats_cursor: None,
             main_btree: None,
+            pending_store_ops: VecDeque::new(),
             search_result: VecDeque::new(),
             insert_state: VectorSparseInvertedIndexInsertState::Init,
             delete_state: VectorSparseInvertedIndexDeleteState::Init,
             search_state: VectorSparseInvertedIndexSearchState::Init,
         }
     }
+
+    fn drive_pending_store_ops(&mut self) -> IOResultOr<()> {
+        while let Some(op) = self.pending_store_ops.front_mut() {
+            return_if_io!(op.step());
+            self.pending_store_ops.pop_front();
+        }
+        Ok(IOResult::Done(()))
+    }
+
+    fn open_store_cursors(&mut self, context: &IndexMethodContext) -> Result<()> {
+        self.inverted_index_cursor = Some(open_store_cursor(context, &self.schema.indexes[0])?);
+        self.stats_cursor = Some(open_store_cursor(context, &self.schema.indexes[1])?);
+        Ok(())
+    }
+}
+
+fn open_store_cursor(
+    context: &IndexMethodContext,
+    index: &BackingIndex,
+) -> Result<Box<dyn CursorTrait>> {
+    context
+        .backing_store(index)?
+        .ok_or_else(|| {
+            LimboError::InternalError(format!("backing store {} not found", index.name))
+        })?
+        .open_cursor()
 }
 
 fn key_info() -> KeyInfo {
@@ -406,108 +450,29 @@ fn key_info() -> KeyInfo {
 
 impl IndexMethodCursor for VectorSparseInvertedIndexMethodCursor {
     fn create(&mut self, context: &IndexMethodContext) -> IOResultOr<()> {
-        // we need to properly track subprograms and propagate result to the root program to make this execution async
-        let connection = context.connection()?;
-        let database_id = context.database().id;
-
-        let columns = &self.configuration.columns;
-        let columns = columns.iter().map(|x| x.name.as_str()).collect::<Vec<_>>();
-        let db_prefix = connection
-            .get_database_name_by_index(database_id)
-            .filter(|name| name != "main")
-            .map(|name| format!("{}.", quote_identifier(&name)))
-            .unwrap_or_default();
-        let quoted_table = quote_identifier(&self.configuration.table_name);
-        let quoted_cols = columns
-            .iter()
-            .map(|c| quote_identifier(c))
-            .collect::<Vec<_>>()
-            .join(", ");
-        let inverted_index_create = format!(
-            "CREATE INDEX {db_prefix}{} ON {quoted_table} USING {BACKING_BTREE_INDEX_METHOD_NAME} ({quoted_cols})",
-            quote_identifier(&self.inverted_index_btree),
-        );
-        let stats_index_create = format!(
-            "CREATE INDEX {db_prefix}{} ON {quoted_table} USING {BACKING_BTREE_INDEX_METHOD_NAME} ({quoted_cols})",
-            quote_identifier(&self.stats_btree),
-        );
-        for sql in [inverted_index_create, stats_index_create] {
-            let mut stmt = connection.prepare(&sql)?;
-            // by default we set needs_stmt_subtransactions = true to all write transaction
-            // this will lead to Busy error here - because Transaction opcode will be unable to acquire ownership to the subjournal as it already owned by parent statement which is still active
-            //
-            // as we run nested statement - we actually don't need subjournal as it already started before in the parent statement
-            // so, this is hacky way to fix the situation for toy index for now, but we need to implement proper helpers in order to avoid similar errors in other code later
-            stmt.program
-                .prepared
-                .needs_stmt_subtransactions
-                .store(false, Ordering::Relaxed);
-            connection.start_nested();
-            let result = stmt.run_ignore_rows();
-            connection.end_nested();
-            result?;
+        if self.pending_store_ops.is_empty() {
+            self.pending_store_ops
+                .push_back(context.create_backing_schema(&self.schema)?);
         }
-
-        Ok(IOResult::Done(()))
+        self.drive_pending_store_ops()
     }
 
     fn destroy(&mut self, context: &IndexMethodContext) -> IOResultOr<()> {
-        let connection = context.connection()?;
-        let database_id = context.database().id;
-        let db_prefix = connection
-            .get_database_name_by_index(database_id)
-            .filter(|name| name != "main")
-            .map(|name| format!("{}.", quote_identifier(&name)))
-            .unwrap_or_default();
-        let inverted_index_drop = format!(
-            "DROP INDEX {db_prefix}{}",
-            quote_identifier(&self.inverted_index_btree)
-        );
-        let stats_index_drop = format!(
-            "DROP INDEX {db_prefix}{}",
-            quote_identifier(&self.stats_btree)
-        );
-        for sql in [inverted_index_drop, stats_index_drop] {
-            let mut stmt = connection.prepare(&sql)?;
-            connection.start_nested();
-            let result = stmt.run_ignore_rows();
-            connection.end_nested();
-            result?;
+        if self.pending_store_ops.is_empty() {
+            self.pending_store_ops
+                .push_back(context.drop_backing_schema(&self.schema)?);
         }
-
-        Ok(IOResult::Done(()))
+        self.drive_pending_store_ops()
     }
 
     fn open_read(&mut self, context: &IndexMethodContext) -> IOResultOr<()> {
-        self.inverted_index_cursor = Some(context.open_index_cursor(
-            &self.configuration.table_name,
-            &self.inverted_index_btree,
-            // component, length, rowid
-            [key_info(), key_info(), key_info()],
-        )?);
-        self.stats_cursor = Some(context.open_index_cursor(
-            &self.configuration.table_name,
-            &self.stats_btree,
-            // component
-            [key_info()],
-        )?);
+        self.open_store_cursors(context)?;
         self.main_btree = Some(context.open_table_cursor(&self.configuration.table_name)?);
         Ok(IOResult::Done(()))
     }
 
     fn open_write(&mut self, context: &IndexMethodContext) -> IOResultOr<()> {
-        self.inverted_index_cursor = Some(context.open_index_cursor(
-            &self.configuration.table_name,
-            &self.inverted_index_btree,
-            // component, length, rowid
-            [key_info(), key_info(), key_info()],
-        )?);
-        self.stats_cursor = Some(context.open_index_cursor(
-            &self.configuration.table_name,
-            &self.stats_btree,
-            // component
-            [key_info()],
-        )?);
+        self.open_store_cursors(context)?;
         Ok(IOResult::Done(()))
     }
 

--- a/core/vdbe/statement_lifecycle_tests.rs
+++ b/core/vdbe/statement_lifecycle_tests.rs
@@ -6,7 +6,7 @@ use crate::mvcc::cursor::CursorYieldPoint;
 use crate::mvcc::yield_hooks::YieldPointMarker;
 use crate::mvcc::yield_points::{YieldInjector, YieldPoint};
 use crate::sync::{Arc, Mutex};
-#[cfg(feature = "fts")]
+#[cfg(any(feature = "fts", feature = "io_memory_yield"))]
 use crate::StepResult;
 use crate::{Connection, Database, DatabaseOpts, LimboError, OpenFlags, Result, Value};
 
@@ -207,14 +207,14 @@ fn fail_rolls_back_base_rows_when_index_method_preparation_fails() {
 /// Delegates to `MemoryIO` and counts every `step` / `wait_for_completion`
 /// made while the test is inside `Statement::step`: that is the engine
 /// pumping I/O synchronously instead of yielding it to the caller.
-#[cfg(feature = "fts")]
+#[cfg(any(feature = "fts", feature = "io_memory_yield"))]
 struct NoPumpInsideStepIo {
     inner: Arc<dyn crate::IO>,
     inside_step: std::sync::atomic::AtomicBool,
     pumps_inside_step: std::sync::atomic::AtomicUsize,
 }
 
-#[cfg(feature = "fts")]
+#[cfg(any(feature = "fts", feature = "io_memory_yield"))]
 impl std::fmt::Debug for NoPumpInsideStepIo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("NoPumpInsideStepIo")
@@ -223,7 +223,7 @@ impl std::fmt::Debug for NoPumpInsideStepIo {
     }
 }
 
-#[cfg(feature = "fts")]
+#[cfg(any(feature = "fts", feature = "io_memory_yield"))]
 impl NoPumpInsideStepIo {
     fn new(inner: Arc<dyn crate::IO>) -> Self {
         Self {
@@ -281,7 +281,7 @@ impl crate::Clock for NoPumpInsideStepIo {
     }
 }
 
-#[cfg(feature = "fts")]
+#[cfg(any(feature = "fts", feature = "io_memory_yield"))]
 impl crate::IO for NoPumpInsideStepIo {
     fn open_file(
         &self,
@@ -564,6 +564,81 @@ fn fts_backing_store_ddl_yields_real_io_on_a_deferred_backend() {
                 "SELECT count(*) FROM docs WHERE fts_match(body, 'fresh')"
             )[0][0],
             Value::from_i64(1),
+            "mvcc={mvcc}"
+        );
+    }
+}
+
+/// The toy vector index creates and drops its backing stores through the
+/// handle that core owns. As a result, its DDL must give its I/O to the
+/// caller, like all other index-method work. It must not run the I/O inside
+/// the opcode.
+#[cfg(feature = "io_memory_yield")]
+#[test]
+fn toy_index_backing_store_ddl_yields_real_io_on_a_deferred_backend() {
+    for mvcc in [false, true] {
+        let io = Arc::new(NoPumpInsideStepIo::new(Arc::new(
+            crate::MemoryYieldIO::new(),
+        )));
+        let db = Database::open_file_with_flags(
+            io.clone(),
+            &format!("toy-ddl-deferred-io-{mvcc}.db"),
+            OpenFlags::default(),
+            DatabaseOpts::new().with_index_method(true),
+            None,
+            Arc::new(SqliteDialect),
+        )
+        .unwrap();
+        let conn = db.connect().unwrap();
+        if mvcc {
+            conn.execute("PRAGMA journal_mode = 'mvcc'").unwrap();
+        }
+        conn.execute("CREATE TABLE vectors(id INTEGER PRIMARY KEY, embedding)")
+            .unwrap();
+        for id in 1..=5 {
+            conn.execute(format!(
+                "INSERT INTO vectors VALUES ({id}, vector32_sparse('[{id}, 0, 1]'))"
+            ))
+            .unwrap();
+        }
+
+        let io_yields = io.drive(
+            &conn,
+            "CREATE INDEX vectors_idx ON vectors USING toy_vector_sparse_ivf (embedding)",
+        );
+        assert!(
+            io_yields > 0,
+            "the deferred backend surfaced no I/O during CREATE INDEX (mvcc={mvcc})"
+        );
+        assert_eq!(
+            io.pumps_inside_step(),
+            0,
+            "CREATE INDEX pumped deferred I/O inside Statement::step (mvcc={mvcc})"
+        );
+        assert_eq!(
+            get_rows(
+                &conn,
+                "SELECT id FROM vectors \
+                 ORDER BY vector_distance_jaccard(embedding, vector32_sparse('[3, 0, 1]')) \
+                 LIMIT 1"
+            )[0][0],
+            Value::from_i64(3),
+            "mvcc={mvcc}"
+        );
+
+        io.drive(&conn, "DROP INDEX vectors_idx");
+        assert_eq!(
+            io.pumps_inside_step(),
+            0,
+            "DROP INDEX pumped deferred I/O inside Statement::step (mvcc={mvcc})"
+        );
+        assert_eq!(
+            get_rows(
+                &conn,
+                "SELECT count(*) FROM sqlite_master \
+                 WHERE name IN ('vectors_idx_inverted_index', 'vectors_idx_stats')"
+            )[0][0],
+            Value::from_i64(0),
             "mvcc={mvcc}"
         );
     }

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -1241,7 +1241,9 @@ Each Index Method consists of three traits that work together (for details, see 
 * **`IndexMethodAttachment`** — represents an Index Method instance bound to a specific table. It can create cursors for query execution and defines the metadata needed for integration with the query planner.
 * **`IndexMethodCursor`** — provides methods for accessing and updating data, as well as for managing the underlying storage during `CREATE INDEX` and `DROP INDEX` operations.
 
-While Index Methods can implement arbitrary logic internally, it's generally recommended to use a B-tree as the underlying storage mechanism. To support this, `tursodb` provides a special `backing_btree` Index Method that other Index Methods can use to create auxiliary tables for storing supporting data.
+An Index Method can store its data in any way. We recommend a B-tree, because the engine already versions B-tree rows under MVCC. For this, the `IndexMethodContext` gives the method backing stores that core owns. A `BackingSchema` lists the tables and the indexes that the method owns. A `BackingTable` is a table that core creates. A `BackingIndex` is a `backing_btree` index on a backing table or on any existing table, with the key layout that the method writes through it. `create_backing_schema` and `drop_backing_schema` return an operation. The cursor steps this operation from `create` and `destroy`. `backing_store` takes one `BackingIndex` and returns a `BackingStore` handle. `open_cursor` on the handle gives a cursor over the rows of the store.
+
+Under MVCC, the handle is bound to the current transaction and snapshot. Rows written through the handle are versioned like the rows of any other table, and the method needs no MVCC-specific code. The method never finds the index or its root page itself.
 
 For more details, see [`toy_vector_sparse_ivf`](../core/index_method/toy_vector_sparse_ivf.rs) implementation.
 


### PR DESCRIPTION
## Description

An index method is a plug-in index type, such as full-text search (FTS). An index method that stores data used to do the work of core itself. FTS built its internal table name, found the backing index in the schema, kept its root page, and derived the MVCC table id from that root at its snapshot. It also ran nested SQL DDL to create and drop the store. The toy vector index had its own copy of the DDL path. A new method would have copied all of this, and the MVCC binding is the part that is easy to get wrong.

This change adds `core/index_method/backing_store.rs`. A method declares the schema objects it owns and gets a handle per index from the `IndexMethodContext`:

- A `BackingSchema` lists the tables and the indexes that the method owns. A `BackingTable` is a table that core creates as `__turso_internal_<name>`. A `BackingIndex` is a `backing_btree` index on a backing table or on any existing table, with the key layout of the records that the method writes through it. A method can declare as many tables and indexes as it needs.
- `context.create_backing_schema(schema)` and `context.drop_backing_schema(schema)` return an operation. The cursor steps the operation from `create` and `destroy`. The nested DDL now lives in core and gives its I/O to the caller.
- `context.backing_store(index)` returns a `BackingStore` handle. The handle is bound one time to the current transaction and snapshot. `open_cursor` gives an MVCC cursor under MVCC and a plain B-tree cursor under WAL. `acquire_maintenance_lease` takes the per-index lease. In WAL mode the lease does nothing.
- The name-based `open_index_cursor` on the context is removed. `open_table_cursor` stays, because a method reads the base table of the user with it.

FTS declares one internal table and one index over `(path, chunk_no, bytes)`, and uses the handle for everything. It does no schema lookup, keeps no root page, resolves no table id, and runs no nested DDL. The toy vector index declares its two existing indexes on the user table. Neither changes its schema objects, so existing databases do not change.

FTS still calls the deleter registration and the merge admission check. These calls now go through crate-private methods on the handle. https://github.com/tursodatabase/turso/pull/8917 deletes that mechanism. The two changes are independent and merge in either order.

## Motivation and context

This is the second step in removing index-method code from the MVCC integration. After it, a new index method needs no MVCC-specific code. The method declares its schema and stores everything as rows through the handles. Core gives the versioning, the snapshot binding, and the lease. The first step is https://github.com/tursodatabase/turso/pull/8917.

Tests: `toy_index_backing_store_ddl_yields_real_io_on_a_deferred_backend` in the statement lifecycle tests fails without this change, because the toy index ran its DDL I/O inside the opcode. The toy create/destroy tests and the VACUUM tests check that its schema objects did not change. The FTS unit, integration, lifecycle, and fuzz groups cover the FTS change. `docs/manual.md` describes the schema and the handle for method authors.

## Description of AI Usage

Claude Code designed and wrote this change in one session, after a survey of every place where MVCC and FTS touch. The tests above ran in the session. Format and lint checks passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qq7sftGL6RXjxsx6Wf5CfX