### PR TITLE
perf/tpc-h: run tursodb with the io_uring backend

### DIFF
--- a/perf/tpc-h/README.md
+++ b/perf/tpc-h/README.md
@@ -11,8 +11,9 @@ Performance comparison of Turso vs SQLite using the [TPC-H](http://www.tpc.org/t
 That builds `tursodb` in release mode, installs a local `sqlite3`,
 downloads the 1.2 GB TPC-H database if it is not there yet, times every
 query on both engines with the page cache dropped before each one, five
-passes over all the queries, and draws the figure. It takes about half an
-hour and asks for sudo once. You need Rust, `uv` for the plot, and `wget`
+passes over all the queries, and draws the figure. `tursodb` runs with
+the io_uring backend, since the CLI defaults to plain syscalls. It takes
+about half an hour and asks for sudo once. You need Rust, `uv` for the plot, and `wget`
 or `curl` for the download. `REPEATS=1 ./scripts/run.sh` makes one pass
 for a quick look.
 

--- a/perf/tpc-h/compare.sh
+++ b/perf/tpc-h/compare.sh
@@ -47,7 +47,7 @@ for q in $(printf '%s\n' "${QUERY_PATHS[@]}" | sort -V); do
     # Run main branch twice, take best
     main_best=999999
     for i in 1 2; do
-        t=$( { time $MAIN_BIN $DB "$sql" > /dev/null 2>&1; } 2>&1 | grep real | awk -F'[ms]' '{print ($1*60000)+($2*1000)}' )
+        t=$( { time $MAIN_BIN $DB --vfs io_uring "$sql" > /dev/null 2>&1; } 2>&1 | grep real | awk -F'[ms]' '{print ($1*60000)+($2*1000)}' )
         if (( $(echo "$t < $main_best" | bc -l) )); then
             main_best=$t
         fi
@@ -56,7 +56,7 @@ for q in $(printf '%s\n' "${QUERY_PATHS[@]}" | sort -V); do
     # Run current branch twice, take best
     curr_best=999999
     for i in 1 2; do
-        t=$( { time $CURR_BIN $DB "$sql" > /dev/null 2>&1; } 2>&1 | grep real | awk -F'[ms]' '{print ($1*60000)+($2*1000)}' )
+        t=$( { time $CURR_BIN $DB --vfs io_uring "$sql" > /dev/null 2>&1; } 2>&1 | grep real | awk -F'[ms]' '{print ($1*60000)+($2*1000)}' )
         if (( $(echo "$t < $curr_best" | bc -l) )); then
             curr_best=$t
         fi

--- a/perf/tpc-h/run.sh
+++ b/perf/tpc-h/run.sh
@@ -65,7 +65,7 @@ run_query_with_limbo() {
     local query_file=$1
     local query_sql
     query_sql=$(load_query_sql "$query_file")
-    RUST_LOG=off run_timed "$LIMBO_BIN" "$DB_FILE" --quiet --output-mode list -- "$query_sql"
+    RUST_LOG=off run_timed "$LIMBO_BIN" "$DB_FILE" --vfs io_uring --quiet --output-mode list -- "$query_sql"
 }
 
 run_query_with_sqlite() {


### PR DESCRIPTION
The CLI still defaults to the syscall backend on Linux, so the TPC-H numbers were measuring the wrong I/O path. Pass --vfs io_uring in both the sqlite3 comparison driver and compare.sh so every TPC-H run uses the same backend.