### PR TITLE
core/benches: make the MVCC recovery benchmark cheap to set up

### DIFF
--- a/core/benches/mvcc_recovery_benchmark.rs
+++ b/core/benches/mvcc_recovery_benchmark.rs
@@ -66,6 +66,7 @@ fn build_mvcc_db_with_log(populate: impl FnOnce(&Arc<turso_core::Connection>)) -
     conn.execute("PRAGMA journal_mode = 'mvcc'").unwrap();
     conn.execute("PRAGMA mvcc_checkpoint_threshold = -1")
         .unwrap();
+    conn.execute("PRAGMA synchronous = OFF").unwrap();
     conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, v BLOB)")
         .unwrap();
     populate(&conn);
@@ -123,7 +124,7 @@ fn single_frame_with_num_ops(num_ops: u64) -> RecoveryFixture {
 fn bench_recovery(c: &mut Criterion) {
     {
         let mut group = c.benchmark_group("mvcc-recovery/small-frames");
-        for &num_frames in &[1, 100, 1000, 10_000, 100_000, 1_000_000] {
+        for &num_frames in &[1, 100, 1000, 10_000, 100_000] {
             let fixture = build_small_frames(num_frames);
             group.throughput(Throughput::Elements(num_frames));
             group.bench_with_input(
@@ -152,7 +153,7 @@ fn bench_recovery(c: &mut Criterion) {
 
     {
         let mut group = c.benchmark_group("mvcc-recovery/wide-frame");
-        for &num_ops in &[1, 100, 1000, 10_000, 100_000, 1_000_000] {
+        for &num_ops in &[1, 100, 1000, 10_000, 100_000] {
             let fixture = single_frame_with_num_ops(num_ops);
             group.throughput(Throughput::Elements(num_ops));
             group.bench_with_input(


### PR DESCRIPTION
The recovery benchmark builds every fixture before measuring anything, and the fixtures were far more expensive than the measurements. The largest ones inserted a million rows one autocommit transaction at a time, and each commit fsyncs the logical log, so a single run issued 1.1 million fsyncs. On tmpfs that is free, which is why it looked like a 20 minute benchmark on a dev box. On a real disk it is not: on local NVMe the full run took 41 minutes, 18 of them building the one-million frame fixture for an 87 second measurement of an 871 ms recovery. On the nightly runner, whose temp directory is on EBS, the benchmark was still running 35 minutes in when the runner's 92 minute lifetime ended the job.

Populate the fixtures with synchronous=OFF, since recovery is what is measured and how the log was written does not change what recovery reads, and stop at 100k frames and 100k ops per frame. Recovery throughput is linear (about 1.2M frames per second), so the 100k cases show the same trend as the 1M cases at a tenth of the cost.