### PR TITLE
sync: count only relevant cdc changes to expose in the stats

### DIFF
--- a/bindings/javascript/sync/packages/native/promise.test.ts
+++ b/bindings/javascript/sync/packages/native/promise.test.ts
@@ -445,6 +445,35 @@ test('select-after-push', async ({ server }) => {
     }
 })
 
+test('cdc-operations-count', async ({ server }) => {
+    const db = await connect({ path: ':memory:', url: server.dbUrl() });
+    const cdcOperations = async () => (await db.stats()).cdcOperations;
+
+    await db.exec("CREATE TABLE t(x)");
+    expect(await cdcOperations()).toBe(1);
+
+    await db.exec("INSERT INTO t VALUES (1)");
+    expect(await cdcOperations()).toBe(2);
+
+    await db.exec("INSERT INTO t VALUES (2), (3)");
+    expect(await cdcOperations()).toBe(4);
+
+    await db.push();
+    expect(await cdcOperations()).toBe(0);
+
+    // pull writes the sync high-water mark into the internal
+    // turso_sync_last_change_id table, which push never sends
+    await db.pull();
+    expect(await cdcOperations()).toBe(0);
+
+    await db.exec("UPDATE t SET x = 10 WHERE x = 1");
+    await db.exec("DELETE FROM t WHERE x = 2");
+    expect(await cdcOperations()).toBe(2);
+
+    await db.push();
+    expect(await cdcOperations()).toBe(0);
+})
+
 test('select-without-push', async ({ server }) => {
     {
         const db = await connect({ path: ':memory:', url: server.dbUrl() });

--- a/sync/engine/src/database_sync_engine.rs
+++ b/sync/engine/src/database_sync_engine.rs
@@ -1438,7 +1438,7 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
             WAL_FRAME_HEADER as u64 + WAL_FRAME_SIZE as u64 * main_wal_frames
         };
         Ok(SyncEngineStats {
-            cdc_operations: count_local_changes(coro, &main_conn, change_id).await?,
+            cdc_operations: count_local_changes(coro, &main_conn, &self.opts, change_id).await?,
             main_wal_size,
             revert_wal_size,
             last_pull_unix_time,
@@ -2166,7 +2166,8 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
             let (_, local_last_change_id) =
                 read_last_change_id(coro, &conn, &self.client_unique_id).await?;
             let pending_local_changes =
-                count_local_changes(coro, &conn, local_last_change_id.unwrap_or(0)).await?;
+                count_local_changes(coro, &conn, &self.opts, local_last_change_id.unwrap_or(0))
+                    .await?;
             if pending_local_changes != 0 {
                 return Err(Error::DatabaseSyncEngineError(format!(
                     "replace-base page apply with pending local CDC changes is not wired yet: {pending_local_changes} local changes need replay"
@@ -4260,9 +4261,10 @@ mod tests {
                     read_last_change_id(&coro, &conn, &engine.client_unique_id)
                         .await
                         .unwrap();
-                let pending_local_changes = count_local_changes(&coro, &conn, change_id.unwrap())
-                    .await
-                    .unwrap();
+                let pending_local_changes =
+                    count_local_changes(&coro, &conn, &engine.opts, change_id.unwrap())
+                        .await
+                        .unwrap();
                 let meta = engine.meta.lock().unwrap().clone();
                 (rows, meta, pull_gen, change_id, pending_local_changes)
             }
@@ -4460,7 +4462,7 @@ mod tests {
                         .await
                         .unwrap();
                 let pending_local_changes =
-                    count_local_changes(&coro, &conn, synced_change_id.unwrap())
+                    count_local_changes(&coro, &conn, &engine.opts, synced_change_id.unwrap())
                         .await
                         .unwrap();
                 let meta = engine.meta.lock().unwrap().clone();

--- a/sync/engine/src/database_sync_operations.rs
+++ b/sync/engine/src/database_sync_operations.rs
@@ -79,6 +79,7 @@ const SQLITE_SCHEMA_TABLE: &str = "sqlite_schema";
 const TURSO_INTERNAL_PREFIX: &str = "__turso_internal_";
 const TURSO_CDC_TABLE_NAME: &str = "turso_cdc";
 const TURSO_CDC_VERSION_TABLE_NAME: &str = "turso_cdc_version";
+const CDC_COMMIT_CHANGE_TYPE: i64 = 2;
 
 #[derive(prost::Message, Clone, PartialEq, Eq)]
 struct PortableLogicalTxn {
@@ -327,6 +328,17 @@ pub(crate) fn is_logically_replayable_table(name: &str) -> bool {
         && name != TURSO_SYNC_TABLE_NAME
         && name != TURSO_CDC_TABLE_NAME
         && name != TURSO_CDC_VERSION_TABLE_NAME
+}
+
+/// SQL form of [`is_logically_replayable_table`] over a `table_name` column.
+/// GLOB is used instead of LIKE because `_` is a wildcard for LIKE but a plain
+/// character for GLOB, and every prefix here contains underscores.
+fn logically_replayable_table_filter() -> String {
+    format!(
+        "table_name NOT GLOB '{SQLITE_INTERNAL_PREFIX}*' \
+         AND table_name NOT GLOB '{TURSO_INTERNAL_PREFIX}*' \
+         AND table_name NOT IN ('{TURSO_SYNC_TABLE_NAME}', '{TURSO_CDC_TABLE_NAME}', '{TURSO_CDC_VERSION_TABLE_NAME}')"
+    )
 }
 
 fn sqlite_schema_change_name(change: &DatabaseTapeRowChange) -> Result<Option<String>> {
@@ -2485,13 +2497,41 @@ pub async fn has_table<Ctx>(
     Ok(count > 0)
 }
 
+/// Counts local changes above `change_id` which the next push will send to the remote.
+/// Rows the push loop drops - COMMIT markers and changes to internal tables like
+/// `turso_sync_last_change_id` - must not be counted, otherwise callers see pending
+/// work which no push can ever clear.
+///
+/// COMMIT markers are dropped by `change_type != COMMIT`, which also drops the CDC v2
+/// records that store a NULL change type. `sqlite_schema` rows are always counted even
+/// though push drops the ones which describe internal objects: telling those apart needs
+/// the row payload decoded, so this can overcount DDL on internal tables.
 pub async fn count_local_changes<Ctx>(
     coro: &Coro<Ctx>,
     conn: &Arc<turso_core::Connection>,
+    opts: &DatabaseSyncEngineOpts,
     change_id: i64,
 ) -> Result<i64> {
-    let mut stmt = conn.prepare("SELECT COUNT(*) FROM turso_cdc WHERE change_id > ?")?;
+    let ignored_placeholders = vec!["?"; opts.tables_ignore.len()].join(", ");
+    let ignored_filter = if opts.tables_ignore.is_empty() {
+        String::new()
+    } else {
+        format!(" AND table_name NOT IN ({ignored_placeholders})")
+    };
+    let mut stmt = conn.prepare(format!(
+        "SELECT COUNT(*) FROM {TURSO_CDC_TABLE_NAME} \
+         WHERE change_id > ? \
+           AND change_type != {CDC_COMMIT_CHANGE_TYPE} \
+           AND (table_name = '{SQLITE_SCHEMA_TABLE}' OR ({})){ignored_filter}",
+        logically_replayable_table_filter(),
+    ))?;
     stmt.bind_at(1.try_into().unwrap(), Value::from_i64(change_id))?;
+    for (i, table) in opts.tables_ignore.iter().enumerate() {
+        stmt.bind_at(
+            (i + 2).try_into().unwrap(),
+            Value::Text(Text::new(table.clone())),
+        )?;
+    }
 
     let count = match run_stmt_expect_one_row(coro, &mut stmt).await? {
         Some(row) => row[0]
@@ -3943,12 +3983,15 @@ mod tests {
         database_sync_engine_io::{DataCompletion, DataPollResult, SyncEngineIo},
         database_sync_operations::{
             apply_logical_transactions_file_without_commit_excluding_client_txns_with_table_map_and_stats,
-            detect_remote_pull_protocol, ensure_incremental_page_stream, ensure_page_stream,
-            is_logically_replayable_table, logical_txn_to_tape_operations, pull_pages_v1,
-            pull_updates_v1, should_push_change, should_replay_local_change, wait_proto_message,
+            count_local_changes, detect_remote_pull_protocol, ensure_incremental_page_stream,
+            ensure_page_stream, is_logically_replayable_table, logical_txn_to_tape_operations,
+            logically_replayable_table_filter, pull_pages_v1, pull_updates_v1, should_push_change,
+            should_replay_local_change, update_last_change_id, wait_proto_message,
             wal_pull_to_file_v1, PullUpdatesV1Result, SyncEngineIoStats, SyncOperationCtx,
         },
-        database_tape::{run_stmt_once, DatabaseReplaySessionOpts, DatabaseTape},
+        database_tape::{
+            run_stmt_expect_one_row, run_stmt_once, DatabaseReplaySessionOpts, DatabaseTape,
+        },
         server_proto,
         server_proto::{
             PageData, PageSetRawEncodingProto, PullUpdatesApplyMode, PullUpdatesReqProtoBody,
@@ -5538,23 +5581,7 @@ mod tests {
 
     #[test]
     fn push_change_filter_skips_internal_sqlite_schema_objects() {
-        let opts = DatabaseSyncEngineOpts {
-            remote_url: None,
-            client_name: "test-client".to_string(),
-            tables_ignore: Vec::new(),
-            use_transform: false,
-            wal_pull_batch_size: 0,
-            long_poll_timeout: None,
-            protocol_version_hint: crate::types::DatabaseSyncEngineProtocolVersion::V1,
-            bootstrap_if_empty: false,
-            reserved_bytes: 0,
-            db_opts: turso_core::DatabaseOpts::default(),
-            partial_sync_opts: None,
-            remote_encryption_key: None,
-            push_operations_threshold: None,
-            pull_bytes_threshold: None,
-            logical_mvcc_pull: Some(true),
-        };
+        let opts = push_test_opts();
         let internal_schema_change = DatabaseTapeRowChange {
             change_id: 1,
             change_time: 77,
@@ -5630,6 +5657,166 @@ mod tests {
 
         assert!(!should_push_change(&rootpage_only_schema_update, &opts).unwrap());
         assert!(!should_replay_local_change(&rootpage_only_schema_update).unwrap());
+    }
+
+    #[test]
+    fn count_local_changes_counts_only_changes_which_push_will_send() {
+        let db_temp = NamedTempFile::new().unwrap();
+        let io: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new().unwrap());
+        let db = turso_core::Database::open_file(
+            io.clone(),
+            db_temp.path().to_str().unwrap(),
+            Arc::new(SqliteDialect),
+        )
+        .unwrap();
+        let db = Arc::new(DatabaseTape::new(db));
+
+        let mut gen = genawaiter::sync::Gen::new({
+            let db = db.clone();
+            move |coro| async move {
+                let coro: Coro<()> = coro.into();
+                let opts = push_test_opts();
+                let conn = db.connect(&coro).await.unwrap();
+
+                conn.execute("CREATE TABLE t(x)").unwrap();
+                conn.execute("INSERT INTO t VALUES (1)").unwrap();
+                conn.execute("INSERT INTO t VALUES (2), (3)").unwrap();
+                let after_writes = count_local_changes(&coro, &conn, &opts, 0).await.unwrap();
+
+                update_last_change_id(&coro, &conn, "client-a", 1, 0)
+                    .await
+                    .unwrap();
+                let after_first_high_water_mark =
+                    count_local_changes(&coro, &conn, &opts, 0).await.unwrap();
+
+                update_last_change_id(&coro, &conn, "client-a", 2, 3)
+                    .await
+                    .unwrap();
+                let after_second_high_water_mark =
+                    count_local_changes(&coro, &conn, &opts, 0).await.unwrap();
+
+                let ignore_t = DatabaseSyncEngineOpts {
+                    tables_ignore: vec!["t".to_string()],
+                    ..push_test_opts()
+                };
+                let with_ignored_table = count_local_changes(&coro, &conn, &ignore_t, 0)
+                    .await
+                    .unwrap();
+
+                let mut stmt = conn.prepare("SELECT COUNT(*) FROM turso_cdc").unwrap();
+                let cdc_rows = run_stmt_expect_one_row(&coro, &mut stmt)
+                    .await
+                    .unwrap()
+                    .unwrap()[0]
+                    .as_int()
+                    .unwrap();
+                (
+                    after_writes,
+                    after_first_high_water_mark,
+                    after_second_high_water_mark,
+                    with_ignored_table,
+                    cdc_rows,
+                )
+            }
+        });
+        let (
+            after_writes,
+            after_first_high_water_mark,
+            after_second_high_water_mark,
+            with_ignored_table,
+            cdc_rows,
+        ) = loop {
+            match gen.resume_with(Ok(())) {
+                genawaiter::GeneratorState::Yielded(..) => io.step().unwrap(),
+                genawaiter::GeneratorState::Complete(result) => break result,
+            }
+        };
+
+        assert_eq!(after_writes, 4);
+        assert_eq!(after_second_high_water_mark, after_first_high_water_mark);
+        assert_eq!(
+            with_ignored_table,
+            after_second_high_water_mark - 3,
+            "the three rows written to t must drop out"
+        );
+        assert!(cdc_rows > after_second_high_water_mark);
+    }
+
+    #[test]
+    fn sql_table_name_filter_agrees_with_is_logically_replayable_table() {
+        let names = [
+            "t",
+            "items",
+            "turso_data",
+            "sqlite_schema",
+            "sqlite_sequence",
+            "turso_sync_last_change_id",
+            "turso_cdc",
+            "turso_cdc_version",
+            "__turso_internal_mvcc_meta",
+            "sqliteXschema",
+            "__tursoXinternalXmvcc",
+        ];
+
+        let io: Arc<dyn turso_core::IO> = Arc::new(turso_core::MemoryIO::new());
+        let db = turso_core::Database::open_file(io.clone(), ":memory:", Arc::new(SqliteDialect))
+            .unwrap();
+        let db = Arc::new(DatabaseTape::new(db));
+
+        let mut gen = genawaiter::sync::Gen::new({
+            let db = db.clone();
+            move |coro| async move {
+                let coro: Coro<()> = coro.into();
+                let conn = db.connect(&coro).await.unwrap();
+                let mut stmt = conn
+                    .prepare(format!(
+                        "SELECT {} FROM (SELECT ? AS table_name)",
+                        logically_replayable_table_filter()
+                    ))
+                    .unwrap();
+                let mut matched = Vec::new();
+                for name in names {
+                    stmt.reset().unwrap();
+                    stmt.bind_at(1.try_into().unwrap(), turso_core::Value::build_text(name))
+                        .unwrap();
+                    let row = run_stmt_expect_one_row(&coro, &mut stmt).await.unwrap();
+                    matched.push(row.unwrap()[0].as_int().unwrap() == 1);
+                }
+                matched
+            }
+        });
+        let matched = loop {
+            match gen.resume_with(Ok(())) {
+                genawaiter::GeneratorState::Yielded(..) => io.step().unwrap(),
+                genawaiter::GeneratorState::Complete(result) => break result,
+            }
+        };
+
+        let expected = names
+            .iter()
+            .map(|name| is_logically_replayable_table(name))
+            .collect::<Vec<_>>();
+        assert_eq!(matched, expected);
+    }
+
+    fn push_test_opts() -> DatabaseSyncEngineOpts {
+        DatabaseSyncEngineOpts {
+            remote_url: None,
+            client_name: "test-client".to_string(),
+            tables_ignore: Vec::new(),
+            use_transform: false,
+            wal_pull_batch_size: 0,
+            long_poll_timeout: None,
+            protocol_version_hint: crate::types::DatabaseSyncEngineProtocolVersion::V1,
+            bootstrap_if_empty: false,
+            reserved_bytes: 0,
+            db_opts: turso_core::DatabaseOpts::default(),
+            partial_sync_opts: None,
+            remote_encryption_key: None,
+            push_operations_threshold: None,
+            pull_bytes_threshold: None,
+            logical_mvcc_pull: Some(true),
+        }
     }
 
     fn page_header(stream_kind: i32, apply_mode: i32) -> PullUpdatesRespProtoBody {


### PR DESCRIPTION
## Description

`SyncEngineStats.cdc_operations` — exposed as `cdcOperations` by every binding and documented as
"amount of local changes not sent to the remote" — counted raw CDC rows:

```sql
SELECT COUNT(*) FROM turso_cdc WHERE change_id > ?
```

That includes rows the push loop never sends, so the number was wrong in two ways:

- **COMMIT markers** (`change_type = 2`, one per statement). The last one always sits above the
  pushed high-water mark, so the count never dropped to zero after a push.
- **internal-table rows** — `turso_sync_last_change_id` (written by every pull),
  `turso_cdc`, `turso_cdc_version`, `sqlite_%`, `__turso_internal_%`, and tables listed in
  `tables_ignore`. `push_logical_changes` drops all of these via `should_push_change`, so they
  stayed in the count forever.

Measured against a local sync server:

| step | before | after |
|---|---|---|
| `CREATE TABLE t(x)` | 2 | 1 |
| `INSERT INTO t VALUES (1)` | 4 | 2 |
| `INSERT INTO t VALUES (2), (3)` | 7 | 4 |
| `push()` | **1** | **0** |
| `pull()` | 2 | 0 |
| `UPDATE` + `DELETE` | 5 | 2 |
| `push()` | **1** | **0** |

`count_local_changes` now applies the push filter in the query itself:

```sql
SELECT COUNT(*) FROM turso_cdc
WHERE change_id > ?
  AND change_type != 2
  AND (table_name = 'sqlite_schema'
       OR (table_name NOT GLOB 'sqlite_*'
           AND table_name NOT GLOB '__turso_internal_*'
           AND table_name NOT IN ('turso_sync_last_change_id','turso_cdc','turso_cdc_version')))
  [AND table_name NOT IN (?, ...)]   -- opts.tables_ignore
```

Still one scan with no per-row decode, so the cost shape is unchanged from the original `COUNT(*)`.

Details worth a reviewer's attention:

- **GLOB, not LIKE.** `_` is a wildcard for LIKE but a plain character for GLOB, and every prefix
  here is full of underscores.
- **`change_type != 2`** drops COMMIT markers in both CDC v2 encodings: the numeric one, and the
  all-NULL-payload one where `NULL != 2` is NULL and the row falls out.
- **Accepted overcount.** `sqlite_schema` rows are always counted, so DDL against an internal table
  (e.g. the `CREATE TABLE IF NOT EXISTS turso_sync_last_change_id` on first pull) can inflate the
  number by one. Telling those apart needs the row payload decoded, which is exactly the per-row
  cost this query avoids. Noted in the function's doc comment.
- The SQL name filter is generated by `logically_replayable_table_filter()` from the same constants
  `is_logically_replayable_table` uses, and a test runs the predicate over 11 names and compares it
  against the Rust function, so the two cannot drift silently.

`count_local_changes` keeps its connection-based signature with `opts` added, so the call-site churn
is four one-line changes.

## Motivation and context

The stat is what callers use to decide whether a push is worth making — the JS docs describe it that
way and our own `concurrent-actions-consistency` test gates `push()` on `cdcOperations > 0`. Because
it never reached zero, that check was always true and the number shown to users never matched the
work actually pending.

## Tests

- `count_local_changes_counts_only_changes_which_push_will_send` — 4 pending after DDL plus three
  inserted rows (the old query returned 7 here, so it fails without the fix); writing the sync
  high-water mark again leaves the count unchanged; `tables_ignore: ["t"]` drops exactly the three
  `t` rows; the raw CDC row count stays strictly larger.
- `sql_table_name_filter_agrees_with_is_logically_replayable_table` — the drift guard described above.
- `cdc-operations-count` (JS, `bindings/javascript/sync/packages/native/promise.test.ts`) — walks
  DDL, single- and multi-row inserts, push, pull, update + delete, push, asserting the exact count at
  each step and 0 after every push.

Validation: `cargo test -p turso_sync_engine` (98 passed) and the full native JS sync suite against a
local `tursodb` sync server (34 passed, 5 skipped — those need Turso Cloud). `cargo fmt` and
`cargo clippy -p turso_sync_engine --all-targets` are clean.

## Description of AI Usage

Written with Claude Code (Opus 5), driven by review rather than one-shot generation. I reported the
symptom — `cdcOperations` not reaching zero after a push, with `turso_sync_last_change_id` as the
suspected cause — and asked for a test before a fix. Claude reproduced it end to end against a local
sync server, then landed a first version that iterated the CDC tape row by row and reused
`should_push_change` for an exact count. I rejected that as too slow and asked for a single SQL query
with a filter, accepting an overestimate on complex schema cases; the current query and its drift
guard came out of that second pass. All test runs above were executed locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
