### PR TITLE
Fix empty wal checkpoint sync

### DIFF
--- a/bindings/javascript/sync/packages/native/index.d.ts
+++ b/bindings/javascript/sync/packages/native/index.d.ts
@@ -230,6 +230,7 @@ export declare class JsProtocolRequestBytes {
 
 export declare class SyncEngine {
   constructor(opts: SyncEngineOpts)
+  filePaths(): Array<string>
   connect(): GeneratorHolder
   ioLoopSync(): void
   /** Runs the I/O loop asynchronously, returning a Promise. */

--- a/bindings/javascript/sync/packages/native/index.js
+++ b/bindings/javascript/sync/packages/native/index.js
@@ -81,8 +81,8 @@ function requireNative() {
       try {
         const binding = require('@tursodatabase/sync-android-arm64')
         const bindingPackageVersion = require('@tursodatabase/sync-android-arm64/package.json').version
-        if (bindingPackageVersion !== '0.8.0-pre.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.8.0-pre.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.8.0-pre.10' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.8.0-pre.10 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -97,8 +97,8 @@ function requireNative() {
       try {
         const binding = require('@tursodatabase/sync-android-arm-eabi')
         const bindingPackageVersion = require('@tursodatabase/sync-android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '0.8.0-pre.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.8.0-pre.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.8.0-pre.10' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.8.0-pre.10 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -117,8 +117,8 @@ function requireNative() {
       try {
         const binding = require('@tursodatabase/sync-win32-x64-msvc')
         const bindingPackageVersion = require('@tursodatabase/sync-win32-x64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.8.0-pre.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.8.0-pre.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.8.0-pre.10' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.8.0-pre.10 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -133,8 +133,8 @@ function requireNative() {
       try {
         const binding = require('@tursodatabase/sync-win32-ia32-msvc')
         const bindingPackageVersion = require('@tursodatabase/sync-win32-ia32-msvc/package.json').version
-        if (bindingPackageVersion !== '0.8.0-pre.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.8.0-pre.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.8.0-pre.10' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.8.0-pre.10 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -149,8 +149,8 @@ function requireNative() {
       try {
         const binding = require('@tursodatabase/sync-win32-arm64-msvc')
         const bindingPackageVersion = require('@tursodatabase/sync-win32-arm64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.8.0-pre.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.8.0-pre.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.8.0-pre.10' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.8.0-pre.10 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -168,8 +168,8 @@ function requireNative() {
     try {
       const binding = require('@tursodatabase/sync-darwin-universal')
       const bindingPackageVersion = require('@tursodatabase/sync-darwin-universal/package.json').version
-      if (bindingPackageVersion !== '0.8.0-pre.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 0.8.0-pre.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+      if (bindingPackageVersion !== '0.8.0-pre.10' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        throw new Error(`Native binding package version mismatch, expected 0.8.0-pre.10 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -184,8 +184,8 @@ function requireNative() {
       try {
         const binding = require('@tursodatabase/sync-darwin-x64')
         const bindingPackageVersion = require('@tursodatabase/sync-darwin-x64/package.json').version
-        if (bindingPackageVersion !== '0.8.0-pre.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.8.0-pre.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.8.0-pre.10' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.8.0-pre.10 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -200,8 +200,8 @@ function requireNative() {
       try {
         const binding = require('@tursodatabase/sync-darwin-arm64')
         const bindingPackageVersion = require('@tursodatabase/sync-darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '0.8.0-pre.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.8.0-pre.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.8.0-pre.10' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.8.0-pre.10 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -220,8 +220,8 @@ function requireNative() {
       try {
         const binding = require('@tursodatabase/sync-freebsd-x64')
         const bindingPackageVersion = require('@tursodatabase/sync-freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '0.8.0-pre.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.8.0-pre.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.8.0-pre.10' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.8.0-pre.10 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -236,8 +236,8 @@ function requireNative() {
       try {
         const binding = require('@tursodatabase/sync-freebsd-arm64')
         const bindingPackageVersion = require('@tursodatabase/sync-freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '0.8.0-pre.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.8.0-pre.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.8.0-pre.10' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.8.0-pre.10 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -257,8 +257,8 @@ function requireNative() {
         try {
           const binding = require('@tursodatabase/sync-linux-x64-musl')
           const bindingPackageVersion = require('@tursodatabase/sync-linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '0.8.0-pre.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.8.0-pre.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.8.0-pre.10' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.8.0-pre.10 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -273,8 +273,8 @@ function requireNative() {
         try {
           const binding = require('@tursodatabase/sync-linux-x64-gnu')
           const bindingPackageVersion = require('@tursodatabase/sync-linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.8.0-pre.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.8.0-pre.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.8.0-pre.10' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.8.0-pre.10 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -291,8 +291,8 @@ function requireNative() {
         try {
           const binding = require('@tursodatabase/sync-linux-arm64-musl')
           const bindingPackageVersion = require('@tursodatabase/sync-linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '0.8.0-pre.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.8.0-pre.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.8.0-pre.10' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.8.0-pre.10 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -307,8 +307,8 @@ function requireNative() {
         try {
           const binding = require('@tursodatabase/sync-linux-arm64-gnu')
           const bindingPackageVersion = require('@tursodatabase/sync-linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.8.0-pre.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.8.0-pre.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.8.0-pre.10' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.8.0-pre.10 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -325,8 +325,8 @@ function requireNative() {
         try {
           const binding = require('@tursodatabase/sync-linux-arm-musleabihf')
           const bindingPackageVersion = require('@tursodatabase/sync-linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '0.8.0-pre.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.8.0-pre.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.8.0-pre.10' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.8.0-pre.10 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -341,8 +341,8 @@ function requireNative() {
         try {
           const binding = require('@tursodatabase/sync-linux-arm-gnueabihf')
           const bindingPackageVersion = require('@tursodatabase/sync-linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '0.8.0-pre.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.8.0-pre.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.8.0-pre.10' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.8.0-pre.10 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -359,8 +359,8 @@ function requireNative() {
         try {
           const binding = require('@tursodatabase/sync-linux-riscv64-musl')
           const bindingPackageVersion = require('@tursodatabase/sync-linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '0.8.0-pre.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.8.0-pre.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.8.0-pre.10' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.8.0-pre.10 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -375,8 +375,8 @@ function requireNative() {
         try {
           const binding = require('@tursodatabase/sync-linux-riscv64-gnu')
           const bindingPackageVersion = require('@tursodatabase/sync-linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.8.0-pre.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.8.0-pre.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.8.0-pre.10' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.8.0-pre.10 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -392,8 +392,8 @@ function requireNative() {
       try {
         const binding = require('@tursodatabase/sync-linux-ppc64-gnu')
         const bindingPackageVersion = require('@tursodatabase/sync-linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.8.0-pre.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.8.0-pre.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.8.0-pre.10' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.8.0-pre.10 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -408,8 +408,8 @@ function requireNative() {
       try {
         const binding = require('@tursodatabase/sync-linux-s390x-gnu')
         const bindingPackageVersion = require('@tursodatabase/sync-linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '0.8.0-pre.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.8.0-pre.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.8.0-pre.10' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.8.0-pre.10 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -428,8 +428,8 @@ function requireNative() {
       try {
         const binding = require('@tursodatabase/sync-openharmony-arm64')
         const bindingPackageVersion = require('@tursodatabase/sync-openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '0.8.0-pre.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.8.0-pre.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.8.0-pre.10' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.8.0-pre.10 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -444,8 +444,8 @@ function requireNative() {
       try {
         const binding = require('@tursodatabase/sync-openharmony-x64')
         const bindingPackageVersion = require('@tursodatabase/sync-openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '0.8.0-pre.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.8.0-pre.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.8.0-pre.10' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.8.0-pre.10 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -460,8 +460,8 @@ function requireNative() {
       try {
         const binding = require('@tursodatabase/sync-openharmony-arm')
         const bindingPackageVersion = require('@tursodatabase/sync-openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '0.8.0-pre.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.8.0-pre.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.8.0-pre.10' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.8.0-pre.10 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {

--- a/bindings/javascript/sync/packages/native/promise.test.ts
+++ b/bindings/javascript/sync/packages/native/promise.test.ts
@@ -1,4 +1,4 @@
-import { unlinkSync } from "node:fs";
+import { statSync, unlinkSync } from "node:fs";
 import { test as baseTest, expect } from 'vitest'
 import { connect, Database, DatabaseRowMutation, DatabaseRowTransformResult, retryFetch } from './promise.js'
 import { TursoServer } from './turso-server.js'
@@ -220,6 +220,51 @@ test.skipIf(process.env.LOCAL_SYNC_SERVER)('partial sync (query bootstrap strate
     expect(await (await db.prepare("SELECT length(value) as length FROM partial_keyed WHERE key = 1000")).all()).toEqual([{ length: 1024 }]);
     const n2 = await db.stats();
     expect(n1.networkReceivedBytes).toEqual(n2.networkReceivedBytes);
+})
+
+// A partial-sync replica stored in a file uses the sparse IO backend, unlike
+// the ':memory:' replicas of the tests above. Checkpointing twice must work:
+// the first call folds the WAL frames and truncates the WAL file to zero
+// bytes, the second one runs with an empty WAL.
+test('partial sync (checkpoint with empty WAL)', async ({ server }) => {
+    {
+        const db = await connect({
+            path: ':memory:',
+            url: server.dbUrl(),
+            longPollTimeoutMs: 100,
+        });
+        await db.exec("CREATE TABLE IF NOT EXISTS partial(value BLOB)");
+        await db.exec("DELETE FROM partial");
+        await db.exec("INSERT INTO partial SELECT randomblob(1024) FROM generate_series(1, 2000)");
+        await db.push();
+        await db.close();
+    }
+
+    const path = `partial-checkpoint-${(Math.random() * 10000) | 0}.db`;
+    try {
+        const db = await connect({
+            path,
+            url: server.dbUrl(),
+            longPollTimeoutMs: 100,
+            partialSyncExperimental: {
+                bootstrapStrategy: { kind: 'prefix', length: 128 * 1024 },
+                segmentSize: 128 * 1024,
+            },
+        });
+
+        await (await db.prepare("INSERT INTO partial VALUES (randomblob(1024))")).run();
+        expect((await db.stats()).mainWalSize).toBeGreaterThan(0);
+
+        await db.checkpoint();
+        expect((await db.stats()).mainWalSize).toBe(0);
+        expect(statSync(`${path}-wal`).size).toBe(0);
+
+        await db.checkpoint();
+        await db.close();
+    }
+    finally {
+        cleanup(path);
+    }
 })
 
 test('concurrent-actions-consistency', async ({ server }) => {

--- a/bindings/javascript/sync/packages/native/promise.test.ts
+++ b/bindings/javascript/sync/packages/native/promise.test.ts
@@ -225,8 +225,9 @@ test.skipIf(process.env.LOCAL_SYNC_SERVER)('partial sync (query bootstrap strate
 // A partial-sync replica stored in a file uses the sparse IO backend, unlike
 // the ':memory:' replicas of the tests above. Checkpointing twice must work:
 // the first call folds the WAL frames and truncates the WAL file to zero
-// bytes, the second one runs with an empty WAL.
-test('partial sync (checkpoint with empty WAL)', async ({ server }) => {
+// bytes, the second one runs with an empty WAL. Linux-only: the sparse backend
+// exists there only, and elsewhere a file-backed partial replica panics.
+test.runIf(process.platform === 'linux')('partial sync (checkpoint with empty WAL)', async ({ server }) => {
     {
         const db = await connect({
             path: ':memory:',

--- a/bindings/rust/src/sync.rs
+++ b/bindings/rust/src/sync.rs
@@ -1777,7 +1777,11 @@ mod tests {
     /// `:memory:` replicas the other partial-sync tests build. Checkpointing
     /// twice must work: the first call folds the WAL frames and truncates the
     /// WAL file to zero bytes, the second call runs with an empty WAL.
+    ///
+    /// Linux-only: elsewhere a file-backed partial replica gets `PlatformIO`,
+    /// whose `has_hole` panics, so partial sync needs a memory database there.
     #[tokio::test]
+    #[cfg(target_os = "linux")]
     pub async fn test_sync_partial_checkpoint_with_empty_wal() {
         let _ = tracing_subscriber::fmt::try_init();
         let server = TursoServer::new().await.unwrap();

--- a/bindings/rust/src/sync.rs
+++ b/bindings/rust/src/sync.rs
@@ -1773,6 +1773,53 @@ mod tests {
         }
     }
 
+    /// A partial-sync replica on a real file uses `SparseLinuxIo`, unlike the
+    /// `:memory:` replicas the other partial-sync tests build. Checkpointing
+    /// twice must work: the first call folds the WAL frames and truncates the
+    /// WAL file to zero bytes, the second call runs with an empty WAL.
+    #[tokio::test]
+    pub async fn test_sync_partial_checkpoint_with_empty_wal() {
+        let _ = tracing_subscriber::fmt::try_init();
+        let server = TursoServer::new().await.unwrap();
+        server.db_sql("CREATE TABLE t(x)").await.unwrap();
+        server
+            .db_sql("INSERT INTO t SELECT randomblob(1024) FROM generate_series(1, 2000)")
+            .await
+            .unwrap();
+
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("partial.db");
+        let wal_path = dir.path().join("partial.db-wal");
+        let db = crate::sync::Builder::new_remote(path.to_str().unwrap())
+            .with_remote_url(server.db_url())
+            .with_partial_sync_opts_experimental(PartialSyncOpts {
+                bootstrap_strategy: Some(PartialBootstrapStrategy::Prefix { length: 128 * 1024 }),
+                segment_size: 128 * 1024,
+                prefetch: false,
+            })
+            .build()
+            .await
+            .unwrap();
+
+        let conn = db.connect().await.unwrap();
+        conn.execute("INSERT INTO t VALUES (randomblob(1024))", ())
+            .await
+            .unwrap();
+        assert!(
+            std::fs::metadata(&wal_path).unwrap().len() > 0,
+            "local write must leave frames in the main WAL"
+        );
+
+        db.checkpoint().await.unwrap();
+        assert_eq!(
+            std::fs::metadata(&wal_path).unwrap().len(),
+            0,
+            "checkpoint must leave an empty main WAL file"
+        );
+
+        db.checkpoint().await.unwrap();
+    }
+
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     #[ignore = "flaky, see https://github.com/tursodatabase/turso/issues/7087"]
     pub async fn test_sync_parallel_writes_with_sync_ops() {

--- a/sync/engine/src/database_sync_engine.rs
+++ b/sync/engine/src/database_sync_engine.rs
@@ -5257,11 +5257,11 @@ mod tests {
 
     /// `read_wal_salt` is the first read `checkpoint()` performs, and it is
     /// written for a WAL file that may be shorter than one header: a short
-    /// read means "no salt". `SparseLinuxIo` (used only by partial sync)
-    /// returns `UnexpectedEof` instead of a short read, so the same empty
-    /// WAL file that full sync reads as "no salt" makes partial sync fail.
+    /// read means "no salt". Every IO backend must report that short read
+    /// rather than an error, otherwise partial sync (the only user of
+    /// `SparseLinuxIo`) cannot checkpoint an empty WAL.
     #[test]
-    fn read_wal_salt_of_empty_wal_file_diverges_between_platform_and_sparse_io() {
+    fn read_wal_salt_of_empty_wal_file_is_none_on_every_io() {
         let temp_dir = tempfile::TempDir::new().unwrap();
         let wal_path = temp_dir
             .path()
@@ -5274,10 +5274,7 @@ mod tests {
         let sparse_io: Arc<dyn turso_core::IO> =
             Arc::new(crate::sparse_io::SparseLinuxIo::new().unwrap());
 
-        for (name, io, expect_error) in [
-            ("PlatformIO", platform_io, false),
-            ("SparseLinuxIo", sparse_io, true),
-        ] {
+        for (name, io) in [("PlatformIO", platform_io), ("SparseLinuxIo", sparse_io)] {
             let mut gen = genawaiter::sync::Gen::new({
                 let io = io.clone();
                 let wal_path = wal_path.clone();
@@ -5293,22 +5290,7 @@ mod tests {
                     genawaiter::GeneratorState::Complete(result) => break result,
                 }
             };
-            if expect_error {
-                assert!(
-                    matches!(
-                        result,
-                        Err(Error::TursoError(turso_core::LimboError::CompletionError(
-                            turso_core::CompletionError::IOError(
-                                std::io::ErrorKind::UnexpectedEof,
-                                "pread"
-                            )
-                        )))
-                    ),
-                    "{name}: {result:?}"
-                );
-            } else {
-                assert!(matches!(result, Ok(None)), "{name}: {result:?}");
-            }
+            assert!(matches!(result, Ok(None)), "{name}: {result:?}");
         }
     }
 }

--- a/sync/engine/src/database_sync_engine.rs
+++ b/sync/engine/src/database_sync_engine.rs
@@ -3258,8 +3258,8 @@ mod tests {
         },
         database_sync_engine_io::{DataCompletion, DataPollResult, SyncEngineIo},
         database_sync_operations::{
-            count_local_changes, max_local_change_id, read_last_change_id, update_last_change_id,
-            MutexSlot, PullUpdatesV1Result, SyncEngineIoStats,
+            count_local_changes, max_local_change_id, read_last_change_id, read_wal_salt,
+            update_last_change_id, MutexSlot, PullUpdatesV1Result, SyncEngineIoStats,
         },
         database_tape::{run_stmt_once, DatabaseTape, DatabaseTapeOpts},
         errors::Error,
@@ -3271,7 +3271,8 @@ mod tests {
         types::{
             Coro, DatabaseMetadata, DatabasePullRevision, DatabaseSavedConfiguration,
             DatabaseSyncEngineProtocolVersion, DbChangesStatus, DbChangesStreamKind,
-            PartialSyncOpts, RemotePullProtocol, SyncEngineIoResult, DATABASE_METADATA_VERSION,
+            PartialBootstrapStrategy, PartialSyncOpts, RemotePullProtocol, SyncEngineIoResult,
+            DATABASE_METADATA_VERSION,
         },
         Result,
     };
@@ -5118,6 +5119,195 @@ mod tests {
             match gen.resume_with(Ok(())) {
                 genawaiter::GeneratorState::Yielded(..) => io.step().unwrap(),
                 genawaiter::GeneratorState::Complete(result) => break result.unwrap(),
+            }
+        }
+    }
+    /// Bootstraps a replica from a canned page stream, makes one local write,
+    /// then checkpoints twice: the first checkpoint folds the WAL frames and
+    /// truncates the WAL file to zero, the second one runs with an empty WAL.
+    fn bootstrap_and_checkpoint_twice(
+        io: Arc<dyn turso_core::IO>,
+        partial_sync_opts: Option<PartialSyncOpts>,
+        db_name: &str,
+    ) -> Result<()> {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let main_path = temp_dir.path().join(db_name).to_string_lossy().to_string();
+        let remote_path = temp_dir
+            .path()
+            .join("remote.db")
+            .to_string_lossy()
+            .to_string();
+
+        let platform_io: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new().unwrap());
+        let remote_db = turso_core::Database::open_file(
+            platform_io.clone(),
+            &remote_path,
+            Arc::new(SqliteDialect),
+        )
+        .unwrap();
+        let remote_conn = remote_db.connect().unwrap();
+        remote_conn
+            .execute("CREATE TABLE items(id INTEGER PRIMARY KEY, value TEXT)")
+            .unwrap();
+        remote_conn
+            .execute("INSERT INTO items VALUES (1, 'remote-a')")
+            .unwrap();
+        let remote_wal_state = remote_conn.wal_state().unwrap();
+        remote_conn
+            .checkpoint(turso_core::CheckpointMode::Truncate {
+                upper_bound_inclusive: Some(remote_wal_state.max_frame),
+            })
+            .unwrap();
+        drop(remote_conn);
+        drop(remote_db);
+        let remote_bytes = std::fs::read(&remote_path).unwrap();
+        assert!(!remote_bytes.is_empty());
+
+        let bootstrap_response =
+            encoded_page_stream_response(&remote_bytes, "g1:o0", PullUpdatesProtocol::Pages);
+        let sync_io = Arc::new(QueuedSyncEngineIo {
+            responses: Mutex::new(vec![bootstrap_response].into_iter().collect()),
+            requests: Mutex::new(Vec::new()),
+        });
+        let sync_engine_io = SyncEngineIoStats::new(sync_io);
+
+        let mut opts = default_test_opts();
+        opts.remote_url = Some("https://example.com".to_string());
+        opts.bootstrap_if_empty = true;
+        opts.logical_mvcc_pull = Some(false);
+        opts.partial_sync_opts = partial_sync_opts;
+
+        let main_wal_path = create_main_db_wal_path(&main_path);
+        let mut gen = genawaiter::sync::Gen::new({
+            let io = io.clone();
+            move |coro| async move {
+                let coro: Coro<()> = coro.into();
+                let engine = DatabaseSyncEngine::create_db(
+                    &coro,
+                    io.clone(),
+                    sync_engine_io.clone(),
+                    &main_path,
+                    opts,
+                )
+                .await?;
+
+                let conn = engine.connect_rw(&coro).await?;
+                conn.execute("INSERT INTO items VALUES (2, 'local-b')")?;
+                drop(conn);
+
+                assert!(
+                    std::fs::metadata(&main_wal_path).unwrap().len() > 0,
+                    "local write must leave frames in the main WAL"
+                );
+                engine.checkpoint(&coro).await?;
+                assert_eq!(
+                    std::fs::metadata(&main_wal_path).unwrap().len(),
+                    0,
+                    "TRUNCATE checkpoint must leave an empty main WAL file"
+                );
+
+                engine.checkpoint(&coro).await
+            }
+        });
+
+        loop {
+            match gen.resume_with(Ok(())) {
+                genawaiter::GeneratorState::Yielded(..) => io.step().unwrap(),
+                genawaiter::GeneratorState::Complete(result) => break result,
+            }
+        }
+    }
+
+    /// Reported bug: on a partial-sync database `checkpoint()` succeeds while
+    /// the main WAL holds frames, and then fails with
+    /// `I/O error (pread): unexpected end of file` on every checkpoint that
+    /// runs while the WAL is empty.
+    #[test]
+    fn partial_sync_checkpoint_succeeds_when_main_wal_is_empty() {
+        let io: Arc<dyn turso_core::IO> = Arc::new(crate::sparse_io::SparseLinuxIo::new().unwrap());
+        // A prefix covering the whole remote database leaves no holes, so the
+        // failure does not depend on any page being unmaterialized.
+        let result = bootstrap_and_checkpoint_twice(
+            io,
+            Some(PartialSyncOpts {
+                bootstrap_strategy: Some(PartialBootstrapStrategy::Prefix {
+                    length: usize::MAX / 2,
+                }),
+                segment_size: 128 * 1024,
+                prefetch: false,
+            }),
+            "partial.db",
+        );
+        assert!(
+            result.is_ok(),
+            "checkpoint on an empty WAL must not fail: {:?}",
+            result.err()
+        );
+    }
+
+    /// Control for [`partial_sync_checkpoint_succeeds_when_main_wal_is_empty`]:
+    /// the very same sequence over a full-sync replica never fails, because
+    /// `PlatformIO` reports a short read where `SparseLinuxIo` errors out.
+    #[test]
+    fn full_sync_checkpoint_succeeds_when_main_wal_is_empty() {
+        let io: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new().unwrap());
+        let result = bootstrap_and_checkpoint_twice(io, None, "full.db");
+        assert!(result.is_ok(), "{:?}", result.err());
+    }
+
+    /// `read_wal_salt` is the first read `checkpoint()` performs, and it is
+    /// written for a WAL file that may be shorter than one header: a short
+    /// read means "no salt". `SparseLinuxIo` (used only by partial sync)
+    /// returns `UnexpectedEof` instead of a short read, so the same empty
+    /// WAL file that full sync reads as "no salt" makes partial sync fail.
+    #[test]
+    fn read_wal_salt_of_empty_wal_file_diverges_between_platform_and_sparse_io() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let wal_path = temp_dir
+            .path()
+            .join("empty.db-wal")
+            .to_string_lossy()
+            .to_string();
+        std::fs::write(&wal_path, []).unwrap();
+
+        let platform_io: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new().unwrap());
+        let sparse_io: Arc<dyn turso_core::IO> =
+            Arc::new(crate::sparse_io::SparseLinuxIo::new().unwrap());
+
+        for (name, io, expect_error) in [
+            ("PlatformIO", platform_io, false),
+            ("SparseLinuxIo", sparse_io, true),
+        ] {
+            let mut gen = genawaiter::sync::Gen::new({
+                let io = io.clone();
+                let wal_path = wal_path.clone();
+                move |coro| async move {
+                    let coro: Coro<()> = coro.into();
+                    let wal = io.try_open(&wal_path)?.expect("wal file exists");
+                    read_wal_salt(&coro, &wal).await
+                }
+            });
+            let result = loop {
+                match gen.resume_with(Ok(())) {
+                    genawaiter::GeneratorState::Yielded(..) => io.step().unwrap(),
+                    genawaiter::GeneratorState::Complete(result) => break result,
+                }
+            };
+            if expect_error {
+                assert!(
+                    matches!(
+                        result,
+                        Err(Error::TursoError(turso_core::LimboError::CompletionError(
+                            turso_core::CompletionError::IOError(
+                                std::io::ErrorKind::UnexpectedEof,
+                                "pread"
+                            )
+                        )))
+                    ),
+                    "{name}: {result:?}"
+                );
+            } else {
+                assert!(matches!(result, Ok(None)), "{name}: {result:?}");
             }
         }
     }

--- a/sync/engine/src/database_sync_engine.rs
+++ b/sync/engine/src/database_sync_engine.rs
@@ -3258,8 +3258,8 @@ mod tests {
         },
         database_sync_engine_io::{DataCompletion, DataPollResult, SyncEngineIo},
         database_sync_operations::{
-            count_local_changes, max_local_change_id, read_last_change_id, read_wal_salt,
-            update_last_change_id, MutexSlot, PullUpdatesV1Result, SyncEngineIoStats,
+            count_local_changes, max_local_change_id, read_last_change_id, update_last_change_id,
+            MutexSlot, PullUpdatesV1Result, SyncEngineIoStats,
         },
         database_tape::{run_stmt_once, DatabaseTape, DatabaseTapeOpts},
         errors::Error,
@@ -3271,8 +3271,7 @@ mod tests {
         types::{
             Coro, DatabaseMetadata, DatabasePullRevision, DatabaseSavedConfiguration,
             DatabaseSyncEngineProtocolVersion, DbChangesStatus, DbChangesStreamKind,
-            PartialBootstrapStrategy, PartialSyncOpts, RemotePullProtocol, SyncEngineIoResult,
-            DATABASE_METADATA_VERSION,
+            PartialSyncOpts, RemotePullProtocol, SyncEngineIoResult, DATABASE_METADATA_VERSION,
         },
         Result,
     };
@@ -5221,8 +5220,9 @@ mod tests {
     /// Reported bug: on a partial-sync database `checkpoint()` succeeds while
     /// the main WAL holds frames, and then fails with
     /// `I/O error (pread): unexpected end of file` on every checkpoint that
-    /// runs while the WAL is empty.
+    /// runs while the WAL is empty. Linux-only, because `SparseLinuxIo` is.
     #[test]
+    #[cfg(target_os = "linux")]
     fn partial_sync_checkpoint_succeeds_when_main_wal_is_empty() {
         let io: Arc<dyn turso_core::IO> = Arc::new(crate::sparse_io::SparseLinuxIo::new().unwrap());
         // A prefix covering the whole remote database leaves no holes, so the
@@ -5230,7 +5230,7 @@ mod tests {
         let result = bootstrap_and_checkpoint_twice(
             io,
             Some(PartialSyncOpts {
-                bootstrap_strategy: Some(PartialBootstrapStrategy::Prefix {
+                bootstrap_strategy: Some(crate::types::PartialBootstrapStrategy::Prefix {
                     length: usize::MAX / 2,
                 }),
                 segment_size: 128 * 1024,
@@ -5246,8 +5246,8 @@ mod tests {
     }
 
     /// Control for [`partial_sync_checkpoint_succeeds_when_main_wal_is_empty`]:
-    /// the very same sequence over a full-sync replica never fails, because
-    /// `PlatformIO` reports a short read where `SparseLinuxIo` errors out.
+    /// the very same sequence over a full-sync replica, which always worked
+    /// because `PlatformIO` reports a short read at end of file.
     #[test]
     fn full_sync_checkpoint_succeeds_when_main_wal_is_empty() {
         let io: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new().unwrap());
@@ -5259,8 +5259,10 @@ mod tests {
     /// written for a WAL file that may be shorter than one header: a short
     /// read means "no salt". Every IO backend must report that short read
     /// rather than an error, otherwise partial sync (the only user of
-    /// `SparseLinuxIo`) cannot checkpoint an empty WAL.
+    /// `SparseLinuxIo`) cannot checkpoint an empty WAL. Linux-only, because
+    /// `SparseLinuxIo` is.
     #[test]
+    #[cfg(target_os = "linux")]
     fn read_wal_salt_of_empty_wal_file_is_none_on_every_io() {
         let temp_dir = tempfile::TempDir::new().unwrap();
         let wal_path = temp_dir
@@ -5281,7 +5283,7 @@ mod tests {
                 move |coro| async move {
                     let coro: Coro<()> = coro.into();
                     let wal = io.try_open(&wal_path)?.expect("wal file exists");
-                    read_wal_salt(&coro, &wal).await
+                    super::read_wal_salt(&coro, &wal).await
                 }
             });
             let result = loop {

--- a/sync/engine/src/sparse_io.rs
+++ b/sync/engine/src/sparse_io.rs
@@ -80,9 +80,7 @@ impl File for SparseLinuxFile {
             let r = c.as_read();
             let buf = r.buf();
             let buf = buf.as_mut_slice();
-            file.read_exact_at(buf, pos)
-                .map_err(|e| io_error(e, "pread"))?;
-            buf.len() as i32
+            read_at_until_end_of_file(&file, pos, buf)?
         };
         c.complete(nr);
         Ok(c)
@@ -171,6 +169,25 @@ impl File for SparseLinuxFile {
     }
 }
 
+/// Reports a short read at end of file instead of failing, matching
+/// `UnixFile::pread` (see core/io/unix.rs) — callers read fixed-size headers
+/// from files that can be shorter than one header (an empty WAL file) and
+/// treat the short read as "absent", so `read_exact_at` must not be used here.
+/// The `Interrupted` retry is what `read_exact_at` did internally; `read_at`
+/// alone does not retry.
+fn read_at_until_end_of_file(file: &std::fs::File, pos: u64, buf: &mut [u8]) -> Result<i32> {
+    let mut read = 0;
+    while read < buf.len() {
+        match file.read_at(&mut buf[read..], pos + read as u64) {
+            Ok(0) => break,
+            Ok(n) => read += n,
+            Err(e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
+            Err(e) => return Err(io_error(e, "pread")),
+        }
+    }
+    Ok(read as i32)
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
@@ -215,5 +232,44 @@ mod tests {
         file.punch_hole(2 * 4096, 4096).unwrap();
         assert!(file.has_hole(4096 * 2, 4096).unwrap());
         assert!(file.has_hole(4096, 4097).unwrap());
+    }
+    #[test]
+    pub fn pread_reports_short_read_at_end_of_file() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let tmp_path = tmp.into_temp_path();
+        let tmp_path = tmp_path.as_os_str().to_str().unwrap();
+        let io = SparseLinuxIo::new().unwrap();
+        let file = io.open_file(tmp_path, OpenFlags::default(), false).unwrap();
+
+        for (file_len, expected_read) in [(0, 0), (10, 10), (32, 32)] {
+            #[expect(clippy::let_underscore_future)]
+            let _ = file
+                .truncate(file_len, Completion::new_trunc(|_| {}))
+                .unwrap();
+
+            let buffer = Arc::new(Buffer::new_temporary(32));
+            let read = Arc::new(std::sync::atomic::AtomicI32::new(-1));
+            let c = file
+                .pread(
+                    0,
+                    Completion::new_read(buffer.clone(), {
+                        let read = read.clone();
+                        move |result| {
+                            read.store(
+                                result.expect("read past end of file must not fail").1,
+                                std::sync::atomic::Ordering::SeqCst,
+                            );
+                            None
+                        }
+                    }),
+                )
+                .unwrap();
+            assert!(c.succeeded());
+            assert_eq!(
+                read.load(std::sync::atomic::Ordering::SeqCst),
+                expected_read,
+                "32 byte read of a {file_len} byte file"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Description

`checkpoint()` on a partial-sync database failed deterministically whenever the WAL was empty:

- a checkpoint with frames in the WAL succeeds, and its final `TRUNCATE` truncates `-wal` to 0 bytes (`truncate_log`, `core/storage/wal.rs`)
- every subsequent checkpoint while the WAL is empty fails with `I/O error (pread): unexpected end of file`

`checkpoint()` → `checkpoint_passive()` begins by reading the WAL salt, and `read_wal_salt`
(`sync/engine/src/database_sync_operations.rs`) is written for a WAL file that may be shorter than one
32-byte header: its completion callback zero-fills on a short read and returns "no salt". The file still
exists after a truncating checkpoint, so `try_open` returns it and the header read runs against 0 bytes.

Partial sync is the only mode that swaps the IO backend — `persistent_io(partial)` hands out
`SparseLinuxIo` instead of `PlatformIO` (`sync/sdk-kit/src/rsapi.rs`, same in `bindings/javascript/sync/src/lib.rs`)
— and `SparseLinuxFile::pread` used `read_exact_at`, which returns `UnexpectedEof` where a short read was
expected. On Linux `libc::pread` never produces `UnexpectedEof`, so the reported error string could only
come from this one call site.

The fix makes `SparseLinuxFile::pread` report the number of bytes read and stop at end of file, matching
`UnixFile::pread` in `core/io/unix.rs`. Both callers already handle a short read: `read_wal_salt` treats it
as "no salt", and core's page reads treat a zero-length read as an absent page.

Two clarifications on the original report:

- Full-sync replicas were never affected, because they use `PlatformIO`.
- The failure does not depend on unmaterialized pages. The engine-level test bootstraps a prefix covering
  the whole database — zero holes — and still reproduced it, since the failing read is on the `-wal` file
  and not on the database file. Materializing the database cannot avoid it.

## Motivation and context

Reported by a user against both 0.7.2 and 0.8.0-pre.10: `checkpoint()` succeeds while the WAL holds frames
and then fails with `I/O error (pread): unexpected end of file` on every checkpoint that follows, which
leaves a partial-sync replica unable to ever fold its WAL twice in a row.

Every existing partial-sync test — Rust bindings and TS alike — opens the replica at `:memory:`, which maps
to `MemoryIO`, so the entire partial-sync suite ran on the one IO backend that is not affected. The new
tests all use a real file path. Added coverage:

| Test | Layer |
|---|---|
| `partial sync (checkpoint with empty WAL)` in `bindings/javascript/sync/packages/native/promise.test.ts` | e2e through the JS SDK against a local sync server |
| `test_sync_partial_checkpoint_with_empty_wal` in `bindings/rust/src/sync.rs` | e2e through the Rust driver |
| `partial_sync_checkpoint_succeeds_when_main_wal_is_empty` in `sync/engine/src/database_sync_engine.rs` | sync engine, over `SparseLinuxIo` |
| `full_sync_checkpoint_succeeds_when_main_wal_is_empty` (control) | same sequence over `PlatformIO`, passes before and after |
| `read_wal_salt_of_empty_wal_file_is_none_on_every_io` | pins the per-backend behaviour of the failing read |
| `pread_reports_short_read_at_end_of_file` in `sync/engine/src/sparse_io.rs` | 32-byte reads of 0-, 10- and 32-byte files |

Each of those fails before the fix and passes after, except the full-sync control, which exists to show the
failure is partial-sync-specific. The TS test was verified in both directions by rebuilding the napi module
with `read_exact_at` restored and confirming the exact reported error.

The first commit is the reproductions on their own, so the failure is visible in isolation before the fix.

Tests: `turso_sync_engine` 100 pass; `turso --features sync` 35 pass, 1 pre-existing ignore;
`promise.test.ts` 34 pass, 5 skipped (the pre-existing `skipIf(LOCAL_SYNC_SERVER)` tests).

Note for reviewers: `94bc9b2` carries unrelated churn in two checked-in generated files, produced by running
the local debug napi build — 46 version-string lines in `index.js` (`0.8.0-pre.3` → `0.8.0-pre.10`, the
checked-in file was stale) and a missing `filePaths(): Array<string>` declaration in `index.d.ts`. Happy to
strip both from the branch if preferred.

## Description of AI Usage

Driven with Claude Code (Opus 5). It located the root cause from the bug report alone, wrote the
reproductions at the sync-engine, Rust-driver and JS-SDK layers, wrote the `pread` fix, and verified each
test fails without the fix and passes with it. I reviewed the diff and committed it.

Two model conclusions were checked against evidence rather than taken on trust: that the failing read is
`read_wal_salt` (confirmed by tracing showing the second checkpoint dying between two adjacent log
statements whose only intervening IO is that read), and that the bug is independent of page materialization
(confirmed by a hole-free repro, which contradicted the "materializing fixes it" part of the report).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
