### PR TITLE
fuzz: build all libFuzzer targets in CI

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -119,8 +119,6 @@ jobs:
       run: cargo run -p turso_stress --locked -- --nr-threads 2 --nr-iterations 1000
 
   libfuzzer-scalar-func:
-    # Allow this job to fail without failing the entire CI run
-    continue-on-error: true
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 15
     steps:
@@ -139,5 +137,8 @@ jobs:
         cache-on-failure: true
     - name: Install cargo-fuzz
       run: cargo install cargo-fuzz@0.13.0
+    - name: Build all libFuzzer targets
+      run: cargo +nightly-2025-12-17 fuzz build --dev
     - name: Run scalar_func fuzzer
+      continue-on-error: true
       run: cargo +nightly-2025-12-17 fuzz run scalar_func -- -max_total_time=300

--- a/fuzz/fuzz_targets/cast_real.rs
+++ b/fuzz/fuzz_targets/cast_real.rs
@@ -1,7 +1,6 @@
 #![no_main]
 use libfuzzer_sys::{fuzz_target, Corpus};
 use std::error::Error;
-use turso_core::numeric::StrToF64;
 
 fn do_fuzz(text: String) -> Result<Corpus, Box<dyn Error>> {
     let expected = {
@@ -12,10 +11,7 @@ fn do_fuzz(text: String) -> Result<Corpus, Box<dyn Error>> {
     };
 
     let actual = turso_core::numeric::str_to_f64(&text)
-        .map(|v| {
-            let (StrToF64::Fractional(non_nan) | StrToF64::Decimal(non_nan)) = v;
-            f64::from(non_nan)
-        })
+        .map(f64::from)
         .unwrap_or(0.0);
 
     assert_eq!(expected, actual);

--- a/fuzz/fuzz_targets/expression.rs
+++ b/fuzz/fuzz_targets/expression.rs
@@ -76,7 +76,7 @@ impl From<Value> for turso_core::Value {
             Value::Null => turso_core::Value::Null,
             Value::Integer(v) => turso_core::Value::from_i64(v),
             Value::Real(v) => turso_core::Value::from_f64(v),
-            Value::Text(v) => turso_core::Value::from_text(&v),
+            Value::Text(v) => turso_core::Value::from_text(v),
             Value::Blob(v) => turso_core::Value::from_blob(v.to_owned()),
         }
     }
@@ -265,17 +265,23 @@ fn do_fuzz(expr: Expr) -> Result<Corpus, Box<dyn Error>> {
 
     let found = 'value: {
         let io = Arc::new(turso_core::MemoryIO::new());
-        let db = turso_core::Database::open_file(io.clone(), ":memory:", false)?;
+        let db = turso_core::Database::open_file(
+            io.clone(),
+            ":memory:",
+            Arc::new(turso_core::SqliteDialect),
+        )?;
         let conn = db.connect()?;
 
         let mut stmt = conn.prepare(sql)?;
         for (idx, value) in expr.parameters.iter().enumerate() {
-            stmt.bind_at(NonZero::new(idx + 1).unwrap(), value.clone().into())
+            stmt.bind_at(NonZero::new(idx + 1).unwrap(), value.clone().into())?;
         }
         loop {
             use turso_core::StepResult;
             match stmt.step()? {
-                StepResult::IO | StepResult::Yield | StepResult::Sleep { .. } => stmt.run_once()?,
+                StepResult::IO | StepResult::Yield | StepResult::Sleep { .. } => {
+                    stmt.get_pager().io.step()?
+                }
                 StepResult::Row => {
                     let row = stmt.row().unwrap();
                     assert_eq!(row.len(), 1, "expr: {:?}", expr);

--- a/fuzz/fuzz_targets/schema.rs
+++ b/fuzz/fuzz_targets/schema.rs
@@ -335,7 +335,11 @@ fn do_fuzz(Ops(ops): Ops) -> Result<Corpus, Box<dyn Error>> {
     let rusqlite_conn = rusqlite::Connection::open_in_memory()?;
 
     let io = Arc::new(turso_core::MemoryIO::new());
-    let db = turso_core::Database::open_file(io.clone(), ":memory:", false)?;
+    let db = turso_core::Database::open_file(
+        io.clone(),
+        ":memory:",
+        Arc::new(turso_core::SqliteDialect),
+    )?;
     let limbo_conn = db.connect()?;
 
     for op in ops {


### PR DESCRIPTION
## Description

Fix the `cast_real`, `expression`, and `schema` libFuzzer targets so they compile against the current core APIs.

Build every libFuzzer target before starting the timed `scalar_func` run. Compile failures now fail the CI job, while failures from the timed fuzz run remain allowed without failing CI.

## Motivation and context
CI only compiled the `scalar_func` target. Changes to core APIs had therefore left other fuzz targets broken without producing a CI failure.

Compiling every declared target makes API breakage visible when it is introduced and keeps all fuzz targets ready to run.

Narrowing the scope of `continue-on-error: true` in the CI pipeline is intended to ensure that changes affecting the compilation of fuzz tests are caught as soon as possible, while still permitting the actual fuzz run to continue failing without causing the CI run to be marked as failed.

## Testing
  - cargo fmt --all -- --check
  - cargo build
  - cargo clippy --workspace --all-features --all-targets -- --deny=warnings
  - cargo fuzz build --dev
  - make test

## Future work
I have intentionally not added the three fixed fuzz tests in the CI run, as they currently fail quite quickly.
I am planning on submitting fixes for identified fuzz errors in a separate PR shortly after this one has been reviewed and merged.

## Description of AI Usage

I used OpenAI codex to investigate the build failures, and as an assistant while fixing the compilation errors.
All changes have been manually reviewed by me.