### PR TITLE
core/mvcc: fix group commit retry leak

### DIFF
--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -1791,13 +1791,19 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CommitStateMachine<Clock, A> {
                 )
             {
                 self.commit_coordinator.clear_issued();
-                if self.commit_coordinator.take_abandoned(batch.writing.tx_id) {
-                    if self.mvcc_store.txs.get(&batch.writing.tx_id).is_some() {
-                        self.mvcc_store
-                            .rollback_tx_inner(batch.writing.tx_id, None, self.db_id);
+                let writer_is_another_tx = batch.writing.tx_id != self.tx_id;
+                if writer_is_another_tx {
+                    if self.commit_coordinator.take_abandoned(batch.writing.tx_id) {
+                        if self.mvcc_store.txs.get(&batch.writing.tx_id).is_some() {
+                            self.mvcc_store.rollback_tx_inner(
+                                batch.writing.tx_id,
+                                None,
+                                self.db_id,
+                            );
+                        }
+                    } else {
+                        self.commit_coordinator.request_retry(batch.writing.ticket);
                     }
-                } else {
-                    self.commit_coordinator.request_retry(batch.writing.ticket);
                 }
                 self.commit_coordinator.requeue(batch.rest.into_iter());
             } else {

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -19573,7 +19573,16 @@ fn dropped_attached_commit_rolls_back_remaining_attached_mvcc_txs() {
 /// DurableStorage::log_tx returning Busy should not leak pager_commit_lock.
 /// https://github.com/tursodatabase/turso/issues/6753.
 #[test]
-fn busy_from_log_tx_strands_pager_commit_lock_then_blocks_subsequent_commit() {
+fn busy_from_log_tx_does_not_block_subsequent_commit_with_group_commit() {
+    busy_from_log_tx_does_not_block_subsequent_commit(true);
+}
+
+#[test]
+fn busy_from_log_tx_does_not_block_subsequent_commit_without_group_commit() {
+    busy_from_log_tx_does_not_block_subsequent_commit(false);
+}
+
+fn busy_from_log_tx_does_not_block_subsequent_commit(group_commit: bool) {
     use crate::io::FileSyncType;
     use crate::mvcc;
     use crate::mvcc::database::{LogRecord, RowVersion};
@@ -19747,6 +19756,12 @@ fn busy_from_log_tx_strands_pager_commit_lock_then_blocks_subsequent_commit() {
     let conn_a = db.connect().unwrap();
     let conn_b = db.connect().unwrap();
     conn_a
+        .execute(format!(
+            "PRAGMA mvcc_group_commit = {}",
+            if group_commit { "on" } else { "off" }
+        ))
+        .unwrap();
+    conn_a
         .execute("CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)")
         .unwrap();
 
@@ -19773,7 +19788,7 @@ fn busy_from_log_tx_strands_pager_commit_lock_then_blocks_subsequent_commit() {
     conn_b.execute("INSERT INTO t VALUES (2, 'b')").unwrap();
 
     let mut commit_b = conn_b.prepare("COMMIT").unwrap();
-    drive_to_done_or_timeout(&mut commit_b, 30); // this times out if pager_commit_lock is leaked
+    drive_to_done_or_timeout(&mut commit_b, 30); // this times out if pager_commit_lock or the group retry set is leaked
 }
 
 // https://github.com/tursodatabase/turso/issues/6757


### PR DESCRIPTION
When the group commit leader is writing its own log record and the write fails or the statement is dropped before the log offset advances, the cleanup treated the record like another transaction's and asked for a retry of its ticket. Nobody ever takes that retry, because the failed transaction is rolled back by cleanup_dropped_commit. The ticket then sat in the retry set forever and take_work returned no work for every later commit, so every subsequent commit on the store yielded without progress.

Only another transaction's record needs the retry or abandon handling; the leader's own record needs neither.

Tests: the log_tx Busy regression test now runs with group commit both on and off. The on variant hangs without this fix.