### PR TITLE
core/mvcc: compare index keys as bytes without decoding

### DIFF
--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -26,7 +26,7 @@ use crate::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use crate::sync::Arc;
 use crate::sync::{Mutex, RwLock};
 use crate::translate::plan::IterationDirection;
-use crate::types::compare_immutable;
+use crate::types::cmp_raw_in_column;
 use crate::types::IOCompletions;
 use crate::types::IOResult;
 use crate::types::IOResultOr;
@@ -215,29 +215,15 @@ impl SortableIndexKey {
     }
 
     fn compare(&self, other: &Self) -> Result<std::cmp::Ordering> {
+        if self.key.get_payload() == other.key.get_payload() {
+            return Ok(std::cmp::Ordering::Equal);
+        }
         // We sometimes need to compare a shorter key to a longer one,
         // for example when seeking with an index key that is a prefix of the full key.
         let num_cols = self.metadata.num_cols.min(other.metadata.num_cols);
-
-        let mut lhs = self.key.iter()?;
-        let mut rhs = other.key.iter()?;
-
-        for i in 0..num_cols {
-            let lhs_value = lhs.next().expect("we already checked length")?;
-            let rhs_value = rhs.next().expect("we already checked length")?;
-
-            let cmp = compare_immutable(
-                std::iter::once(&lhs_value),
-                std::iter::once(&rhs_value),
-                &self.metadata.key_info[i..i + 1],
-            );
-
-            if cmp != std::cmp::Ordering::Equal {
-                return Ok(cmp);
-            }
-        }
-
-        Ok(std::cmp::Ordering::Equal)
+        Ok(self
+            .compare_columns(other, num_cols)?
+            .expect("we already checked length"))
     }
 
     /// Check if the index key contains any NULL values (excluding the rowid column).
@@ -259,31 +245,24 @@ impl SortableIndexKey {
     /// Used for UNIQUE index conflict detection where we need to compare only
     /// the indexed columns, not the rowid suffix.
     pub fn matches_prefix(&self, other: &Self, num_cols: usize) -> Result<bool> {
+        Ok(self.compare_columns(other, num_cols)? == Some(std::cmp::Ordering::Equal))
+    }
+
+    /// Compares the first `num_cols` columns. `None` when a key has fewer
+    /// columns. TEXT columns compare as bytes, so no UTF-8 validation runs here.
+    fn compare_columns(&self, other: &Self, num_cols: usize) -> Result<Option<std::cmp::Ordering>> {
         let mut lhs = self.key.iter()?;
         let mut rhs = other.key.iter()?;
-
-        for i in 0..num_cols {
-            let lhs_value = match lhs.next() {
-                Some(v) => v?,
-                None => return Ok(false),
+        for key_info in &self.metadata.key_info[..num_cols] {
+            let (Some(lhs_value), Some(rhs_value)) = (lhs.next_raw(), rhs.next_raw()) else {
+                return Ok(None);
             };
-            let rhs_value = match rhs.next() {
-                Some(v) => v?,
-                None => return Ok(false),
-            };
-
-            let cmp = compare_immutable(
-                std::iter::once(&lhs_value),
-                std::iter::once(&rhs_value),
-                &self.metadata.key_info[i..i + 1],
-            );
-
+            let cmp = cmp_raw_in_column(&lhs_value?, &rhs_value?, key_info)?;
             if cmp != std::cmp::Ordering::Equal {
-                return Ok(false);
+                return Ok(Some(cmp));
             }
         }
-
-        Ok(true)
+        Ok(Some(std::cmp::Ordering::Equal))
     }
 }
 

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -215,9 +215,6 @@ impl SortableIndexKey {
     }
 
     fn compare(&self, other: &Self) -> Result<std::cmp::Ordering> {
-        if self.key.get_payload() == other.key.get_payload() {
-            return Ok(std::cmp::Ordering::Equal);
-        }
         // We sometimes need to compare a shorter key to a longer one,
         // for example when seeking with an index key that is a prefix of the full key.
         let num_cols = self.metadata.num_cols.min(other.metadata.num_cols);
@@ -254,7 +251,10 @@ impl SortableIndexKey {
         let mut lhs = self.key.iter()?;
         let mut rhs = other.key.iter()?;
         for key_info in &self.metadata.key_info[..num_cols] {
-            let (Some(lhs_value), Some(rhs_value)) = (lhs.next_raw(), rhs.next_raw()) else {
+            let Some(lhs_value) = lhs.next_raw() else {
+                return Ok(None);
+            };
+            let Some(rhs_value) = rhs.next_raw() else {
                 return Ok(None);
             };
             let cmp = cmp_raw_in_column(&lhs_value?, &rhs_value?, key_info)?;

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -21915,3 +21915,133 @@ fn commit_validation_reports_conflict_for_evicted_tombstone_writer() {
 
 #[path = "group_commit_tests.rs"]
 mod group_commit_tests;
+
+#[test]
+fn index_key_comparison_agrees_with_the_decoded_comparison() {
+    use crate::translate::collate::CollationSeq;
+    use crate::types::{compare_immutable, KeyInfo, TextRef, TextSubtype, ValueRef};
+    use turso_parser::ast::SortOrder;
+
+    let first_column = [
+        ValueRef::Null,
+        ValueRef::from_i64(-5),
+        ValueRef::from_i64(7),
+        ValueRef::from_f64(7.0),
+        ValueRef::from_f64(1.5),
+        ValueRef::Text(TextRef::new("abc", TextSubtype::Text)),
+        ValueRef::Text(TextRef::new("ABC", TextSubtype::Text)),
+        ValueRef::Text(TextRef::new("abc  ", TextSubtype::Text)),
+        ValueRef::Text(TextRef::new("é", TextSubtype::Text)),
+        ValueRef::Text(TextRef::new("z", TextSubtype::Text)),
+        ValueRef::Blob(&[1, 2]),
+        ValueRef::Blob(&[1, 2, 3]),
+    ];
+    let second_column = [
+        ValueRef::from_i64(1),
+        ValueRef::from_i64(2),
+        ValueRef::Text(TextRef::new("x", TextSubtype::Text)),
+    ];
+    let collations = [
+        CollationSeq::Binary,
+        CollationSeq::NoCase,
+        CollationSeq::Rtrim,
+    ];
+    let sort_orders = [SortOrder::Asc, SortOrder::Desc];
+
+    for collation in collations {
+        for first_order in sort_orders {
+            for second_order in sort_orders {
+                let info = std::sync::Arc::new(
+                    IndexInfo::new(
+                        crate::alloc::vec![
+                            KeyInfo {
+                                sort_order: first_order,
+                                collation,
+                                nulls_order: None,
+                            },
+                            KeyInfo {
+                                sort_order: second_order,
+                                collation: CollationSeq::Binary,
+                                nulls_order: None,
+                            },
+                        ],
+                        false,
+                        2,
+                        false,
+                    )
+                    .unwrap(),
+                );
+                let keys: Vec<(Vec<ValueRef>, SortableIndexKey)> = first_column
+                    .iter()
+                    .flat_map(|first| {
+                        second_column
+                            .iter()
+                            .map(move |second| vec![*first, *second])
+                    })
+                    .map(|values| {
+                        let record = ImmutableRecord::from_values(&values, values.len()).unwrap();
+                        let key = SortableIndexKey::new_from_payload_in(
+                            &record,
+                            info.clone(),
+                            crate::alloc::TursoAllocator,
+                        )
+                        .unwrap();
+                        (values, key)
+                    })
+                    .collect();
+                for (lhs_values, lhs) in &keys {
+                    for (rhs_values, rhs) in &keys {
+                        let expected =
+                            compare_immutable(lhs_values.iter(), rhs_values.iter(), &info.key_info);
+                        assert_eq!(
+                            lhs.cmp(rhs),
+                            expected,
+                            "{collation:?} {first_order:?} {second_order:?} {lhs_values:?} vs {rhs_values:?}"
+                        );
+                        assert_eq!(lhs == rhs, expected.is_eq());
+                        assert_eq!(lhs.matches_prefix(rhs, 2).unwrap(), expected.is_eq());
+                        let first_only = compare_immutable(
+                            lhs_values.iter().take(1),
+                            rhs_values.iter().take(1),
+                            &info.key_info[..1],
+                        );
+                        assert_eq!(lhs.matches_prefix(rhs, 1).unwrap(), first_only.is_eq());
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn index_key_comparison_does_not_need_valid_utf8() {
+    use crate::translate::collate::CollationSeq;
+    use crate::types::KeyInfo;
+    use turso_parser::ast::SortOrder;
+
+    let info = std::sync::Arc::new(
+        IndexInfo::new(
+            crate::alloc::vec![KeyInfo {
+                sort_order: SortOrder::Asc,
+                collation: CollationSeq::Binary,
+                nulls_order: None,
+            }],
+            false,
+            1,
+            false,
+        )
+        .unwrap(),
+    );
+    // Header size 2, one TEXT column of two bytes (serial type 13 + 2 * 2).
+    let key = |bytes: [u8; 2]| {
+        let payload = [0x02, 0x11, bytes[0], bytes[1]];
+        SortableIndexKey::new_from_payload_in(payload, info.clone(), crate::alloc::TursoAllocator)
+            .unwrap()
+    };
+    let lower = key([0xff, 0xfe]);
+    let higher = key([0xff, 0xff]);
+    assert_eq!(lower.cmp(&higher), std::cmp::Ordering::Less);
+    assert_eq!(lower.cmp(&lower), std::cmp::Ordering::Equal);
+    assert!(!lower.matches_prefix(&higher, 1).unwrap());
+    assert!(lower.key.iter().unwrap().next().unwrap().is_err());
+}

--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -72,7 +72,7 @@ use crate::storage::wal::READMARK_NOT_USED;
 use crate::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, AtomicUsize, Ordering};
 use crate::sync::Arc;
 use crate::sync::RwLock;
-use crate::types::{SerialType, SerialTypeKind, TextRef, TextSubtype, ValueRef};
+use crate::types::{RawValueRef, SerialType, SerialTypeKind, TextRef, TextSubtype, ValueRef};
 use crate::{bail_corrupt_error, CompletionError, File, IOContext, Result, WalFileShared};
 use rustc_hash::FxHashMap;
 use std::collections::BTreeMap;
@@ -1145,14 +1145,27 @@ pub fn read_value_serial_type<'a>(
     buf: &'a [u8],
     serial_type: u64,
 ) -> Result<(ValueRef<'a>, usize)> {
+    let (value, size) = read_raw_value_serial_type(buf, serial_type)?;
+    Ok((value.to_value_ref()?, size))
+}
+
+/// Decodes one record value. TEXT stays bytes: the caller validates UTF-8
+/// only when it needs a `str`.
+pub fn read_raw_value_serial_type<'a>(
+    buf: &'a [u8],
+    serial_type: u64,
+) -> Result<(RawValueRef<'a>, usize)> {
     match serial_type {
-        0 => Ok((ValueRef::Null, 0)),
+        0 => Ok((RawValueRef::Null, 0)),
         1 => {
             if buf.is_empty() {
                 mark_unlikely();
                 crate::bail_corrupt_error!("Invalid 1-byte int");
             }
-            Ok((ValueRef::Numeric(Numeric::Integer(buf[0] as i8 as i64)), 1))
+            Ok((
+                RawValueRef::Numeric(Numeric::Integer(buf[0] as i8 as i64)),
+                1,
+            ))
         }
         2 => {
             if buf.len() < 2 {
@@ -1160,7 +1173,7 @@ pub fn read_value_serial_type<'a>(
                 crate::bail_corrupt_error!("Invalid 2-byte int");
             }
             Ok((
-                ValueRef::Numeric(Numeric::Integer(i16::from_be_bytes([buf[0], buf[1]]) as i64)),
+                RawValueRef::Numeric(Numeric::Integer(i16::from_be_bytes([buf[0], buf[1]]) as i64)),
                 2,
             ))
         }
@@ -1171,7 +1184,7 @@ pub fn read_value_serial_type<'a>(
             }
             let sign_extension = if buf[0] <= 0x7F { 0 } else { 0xFF };
             Ok((
-                ValueRef::Numeric(Numeric::Integer(i32::from_be_bytes([
+                RawValueRef::Numeric(Numeric::Integer(i32::from_be_bytes([
                     sign_extension,
                     buf[0],
                     buf[1],
@@ -1186,7 +1199,7 @@ pub fn read_value_serial_type<'a>(
                 crate::bail_corrupt_error!("Invalid 4-byte int");
             }
             Ok((
-                ValueRef::Numeric(Numeric::Integer(i32::from_be_bytes([
+                RawValueRef::Numeric(Numeric::Integer(i32::from_be_bytes([
                     buf[0], buf[1], buf[2], buf[3],
                 ]) as i64)),
                 4,
@@ -1199,7 +1212,7 @@ pub fn read_value_serial_type<'a>(
             }
             let sign_extension = if buf[0] <= 0x7F { 0 } else { 0xFF };
             Ok((
-                ValueRef::Numeric(Numeric::Integer(i64::from_be_bytes([
+                RawValueRef::Numeric(Numeric::Integer(i64::from_be_bytes([
                     sign_extension,
                     sign_extension,
                     buf[0],
@@ -1218,7 +1231,7 @@ pub fn read_value_serial_type<'a>(
                 crate::bail_corrupt_error!("Invalid 8-byte int");
             }
             Ok((
-                ValueRef::Numeric(Numeric::Integer(i64::from_be_bytes([
+                RawValueRef::Numeric(Numeric::Integer(i64::from_be_bytes([
                     buf[0], buf[1], buf[2], buf[3], buf[4], buf[5], buf[6], buf[7],
                 ]))),
                 8,
@@ -1230,14 +1243,14 @@ pub fn read_value_serial_type<'a>(
                 crate::bail_corrupt_error!("Invalid 8-byte float");
             }
             Ok((
-                ValueRef::from_f64(f64::from_be_bytes([
+                RawValueRef::from_f64(f64::from_be_bytes([
                     buf[0], buf[1], buf[2], buf[3], buf[4], buf[5], buf[6], buf[7],
                 ])),
                 8,
             ))
         }
-        8 => Ok((ValueRef::Numeric(Numeric::Integer(0)), 0)),
-        9 => Ok((ValueRef::Numeric(Numeric::Integer(1)), 0)),
+        8 => Ok((RawValueRef::Numeric(Numeric::Integer(0)), 0)),
+        9 => Ok((RawValueRef::Numeric(Numeric::Integer(1)), 0)),
         n if n >= 12 => match n % 2 {
             0 => {
                 // Blob
@@ -1246,7 +1259,7 @@ pub fn read_value_serial_type<'a>(
                     mark_unlikely();
                     LimboError::Corrupt("Invalid Blob value".into())
                 })?;
-                Ok((ValueRef::Blob(data), content_size))
+                Ok((RawValueRef::Blob(data), content_size))
             }
             1 => {
                 // Text
@@ -1259,14 +1272,7 @@ pub fn read_value_serial_type<'a>(
                         content_size
                     ))
                 })?;
-                let val = crate::types::validate_utf8(data).ok_or_else(|| {
-                    mark_unlikely();
-                    LimboError::Corrupt("TEXT value contains invalid UTF-8".into())
-                })?;
-                Ok((
-                    ValueRef::Text(TextRef::new(val, TextSubtype::Text)),
-                    content_size,
-                ))
+                Ok((RawValueRef::Text(data), content_size))
             }
             _ => unreachable!(),
         },

--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -1151,6 +1151,7 @@ pub fn read_value_serial_type<'a>(
 
 /// Decodes one record value. TEXT stays bytes: the caller validates UTF-8
 /// only when it needs a `str`.
+#[inline(always)]
 pub fn read_raw_value_serial_type<'a>(
     buf: &'a [u8],
     serial_type: u64,

--- a/core/translate/collate.rs
+++ b/core/translate/collate.rs
@@ -152,25 +152,32 @@ impl CollationSeq {
     #[inline(always)]
     pub fn compare_strings(&self, lhs: &str, rhs: &str) -> Ordering {
         match *self {
-            Self::Unset | Self::Binary => Self::binary_cmp(lhs, rhs),
-            Self::NoCase => Self::nocase_cmp(lhs, rhs),
-            Self::Rtrim => Self::rtrim_cmp(lhs, rhs),
             Self::Locale(id) => LocaleCollationRegistry::global().compare(id, lhs, rhs),
+            _ => self
+                .compare_bytes(lhs.as_bytes(), rhs.as_bytes())
+                .expect("every collation except locale compares bytes"),
+        }
+    }
+
+    /// Compares two TEXT values by their bytes, so an index key needs no UTF-8
+    /// validation to compare. Locale collations need decoded text and give `None`.
+    #[inline(always)]
+    pub fn compare_bytes(&self, lhs: &[u8], rhs: &[u8]) -> Option<Ordering> {
+        match *self {
+            Self::Unset | Self::Binary => Some(lhs.cmp(rhs)),
+            Self::NoCase => Some(Self::nocase_cmp(lhs, rhs)),
+            Self::Rtrim => Some(Self::rtrim_cmp(lhs, rhs)),
+            Self::Locale(_) => None,
             // Immutable comparison paths have no connection to fetch the external
             // callback from. Runtime VDBE paths dispatch custom collations via
             // `Connection`; schema/index paths reject them before storage.
-            Self::Custom(_) => Self::binary_cmp(lhs, rhs),
+            Self::Custom(_) => Some(lhs.cmp(rhs)),
         }
     }
 
     #[inline(always)]
-    fn binary_cmp(lhs: &str, rhs: &str) -> Ordering {
-        lhs.cmp(rhs)
-    }
-
-    #[inline(always)]
-    fn nocase_cmp(lhs: &str, rhs: &str) -> Ordering {
-        for (left, right) in lhs.bytes().zip(rhs.bytes()) {
+    fn nocase_cmp(lhs: &[u8], rhs: &[u8]) -> Ordering {
+        for (left, right) in lhs.iter().zip(rhs) {
             let left = left.to_ascii_lowercase();
             let right = right.to_ascii_lowercase();
             if left != right {
@@ -184,8 +191,16 @@ impl CollationSeq {
     }
 
     #[inline(always)]
-    fn rtrim_cmp(lhs: &str, rhs: &str) -> Ordering {
-        lhs.trim_end_matches(' ').cmp(rhs.trim_end_matches(' '))
+    fn rtrim_cmp(lhs: &[u8], rhs: &[u8]) -> Ordering {
+        Self::without_trailing_spaces(lhs).cmp(Self::without_trailing_spaces(rhs))
+    }
+
+    fn without_trailing_spaces(bytes: &[u8]) -> &[u8] {
+        let end = bytes
+            .iter()
+            .rposition(|&byte| byte != b' ')
+            .map_or(0, |last| last + 1);
+        &bytes[..end]
     }
 
     pub fn hash_key(&self, text: &str) -> Vec<u8> {
@@ -519,6 +534,60 @@ fn get_collseq_parts_from_expr_with_symbols(
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn compare_bytes_matches_the_string_comparison_of_each_collation() {
+        use std::cmp::Ordering;
+
+        use super::CollationSeq;
+
+        fn nocase(lhs: &str, rhs: &str) -> Ordering {
+            for (left, right) in lhs.bytes().zip(rhs.bytes()) {
+                let left = left.to_ascii_lowercase();
+                let right = right.to_ascii_lowercase();
+                if left != right {
+                    return left.cmp(&right);
+                }
+                if left == 0 {
+                    return lhs.len().cmp(&rhs.len());
+                }
+            }
+            lhs.len().cmp(&rhs.len())
+        }
+
+        let samples = [
+            "", "a", "A", "abc", "ABC", "abc  ", "abc ", "ab", "é", "É", "z", "\0a", "a\0", " ",
+        ];
+        for lhs in samples {
+            for rhs in samples {
+                let (l, r) = (lhs.as_bytes(), rhs.as_bytes());
+                assert_eq!(CollationSeq::Binary.compare_bytes(l, r), Some(lhs.cmp(rhs)));
+                assert_eq!(
+                    CollationSeq::NoCase.compare_bytes(l, r),
+                    Some(nocase(lhs, rhs))
+                );
+                assert_eq!(
+                    CollationSeq::Rtrim.compare_bytes(l, r),
+                    Some(lhs.trim_end_matches(' ').cmp(rhs.trim_end_matches(' ')))
+                );
+                for collation in [
+                    CollationSeq::Unset,
+                    CollationSeq::Binary,
+                    CollationSeq::NoCase,
+                    CollationSeq::Rtrim,
+                ] {
+                    assert_eq!(
+                        collation.compare_bytes(l, r),
+                        Some(collation.compare_strings(lhs, rhs))
+                    );
+                }
+            }
+        }
+        assert_eq!(
+            CollationSeq::Binary.compare_bytes(&[0xff, 0xfe], &[0xff, 0xff]),
+            Some(Ordering::Less)
+        );
+    }
+
     use crate::alloc::vec;
     use crate::{sync::Arc, MAIN_DB_ID};
 

--- a/core/types.rs
+++ b/core/types.rs
@@ -2685,16 +2685,29 @@ pub fn cmp_in_column(a: &ValueRef, b: &ValueRef, key: &KeyInfo) -> Ordering {
     cmp_with_sort(compare_immutable_single(a, b, key.collation), a, b, key)
 }
 
-/// `cmp_in_column` for values whose TEXT is still bytes. Two TEXT values under
-/// a byte-level collation compare without UTF-8 validation. Every other pair
-/// validates and takes the decoded path.
+/// `cmp_in_column` for values whose TEXT is still bytes. Only two TEXT values
+/// under a collation that needs `str` decode; every other pair compares as
+/// `ValueRef` does.
+#[inline]
 pub fn cmp_raw_in_column(a: &RawValueRef, b: &RawValueRef, key: &KeyInfo) -> Result<Ordering> {
-    if let (RawValueRef::Text(left), RawValueRef::Text(right)) = (a, b) {
-        if let Some(cmp) = key.collation.compare_bytes(left, right) {
-            return Ok(sort_ordering(cmp, false, key));
+    let (cmp, involves_null) = match (a, b) {
+        (RawValueRef::Null, RawValueRef::Null) => (Ordering::Equal, true),
+        (RawValueRef::Null, _) => (Ordering::Less, true),
+        (_, RawValueRef::Null) => (Ordering::Greater, true),
+        (RawValueRef::Numeric(left), RawValueRef::Numeric(right)) => (left.cmp(right), false),
+        (RawValueRef::Numeric(_), _) => (Ordering::Less, false),
+        (_, RawValueRef::Numeric(_)) => (Ordering::Greater, false),
+        (RawValueRef::Text(left), RawValueRef::Text(right)) => {
+            match key.collation.compare_bytes(left, right) {
+                Some(cmp) => (cmp, false),
+                None => return Ok(cmp_in_column(&a.to_value_ref()?, &b.to_value_ref()?, key)),
+            }
         }
-    }
-    Ok(cmp_in_column(&a.to_value_ref()?, &b.to_value_ref()?, key))
+        (RawValueRef::Text(_), RawValueRef::Blob(_)) => (Ordering::Less, false),
+        (RawValueRef::Blob(_), RawValueRef::Text(_)) => (Ordering::Greater, false),
+        (RawValueRef::Blob(left), RawValueRef::Blob(right)) => (left.cmp(right), false),
+    };
+    Ok(sort_ordering(cmp, involves_null, key))
 }
 
 /// Outputs a modified [Ordering] that takes into account the sort order and the NULLS order.

--- a/core/types.rs
+++ b/core/types.rs
@@ -15,7 +15,8 @@ use crate::pseudo::PseudoCursor;
 use crate::schema::Index;
 use crate::storage::btree::{BTreeCursor, CursorTrait};
 use crate::storage::sqlite3_ondisk::{
-    read_integer, read_value, read_value_serial_type, read_varint, varint_len, write_varint,
+    read_integer, read_raw_value_serial_type, read_value, read_value_serial_type, read_varint,
+    varint_len, write_varint,
 };
 use crate::translate::collate::CollationSeq;
 use crate::translate::plan::IterationDirection;
@@ -495,6 +496,41 @@ pub enum ValueRef<'a> {
     Numeric(Numeric),
     Text(TextRef<'a>),
     Blob(&'a [u8]),
+}
+
+/// A record value before UTF-8 validation of its TEXT. Index keys compare
+/// through this type, because a byte order needs no `str`. `to_value_ref`
+/// validates when a `str` is needed.
+#[derive(Debug, Clone, Copy)]
+pub enum RawValueRef<'a> {
+    Null,
+    Numeric(Numeric),
+    Text(&'a [u8]),
+    Blob(&'a [u8]),
+}
+
+impl<'a> RawValueRef<'a> {
+    pub fn from_f64(f: f64) -> Self {
+        match NonNan::new(f) {
+            Some(nn) => Self::Numeric(Numeric::Float(nn)),
+            None => Self::Null,
+        }
+    }
+
+    pub fn to_value_ref(&self) -> Result<ValueRef<'a>> {
+        Ok(match *self {
+            Self::Null => ValueRef::Null,
+            Self::Numeric(numeric) => ValueRef::Numeric(numeric),
+            Self::Text(bytes) => {
+                let text = validate_utf8(bytes).ok_or_else(|| {
+                    mark_unlikely();
+                    LimboError::Corrupt("TEXT value contains invalid UTF-8".into())
+                })?;
+                ValueRef::Text(TextRef::new(text, TextSubtype::Text))
+            }
+            Self::Blob(bytes) => ValueRef::Blob(bytes),
+        })
+    }
 }
 
 impl Debug for ValueRef<'_> {
@@ -2201,29 +2237,56 @@ impl<'a> Iterator for ValueIterator<'a> {
 
     #[inline(always)]
     fn next(&mut self) -> Option<Self::Item> {
-        let header = self.header_section.get();
-        if unlikely(header.is_empty()) {
-            return None;
-        }
-
-        // Read next serial type
-        let (serial_type, bytes_read) = match read_varint(header) {
-            Ok(v) => v,
-            Err(e) => {
-                mark_unlikely();
-                return Some(Err(e));
-            }
+        let serial_type = match self.next_serial_type()? {
+            Ok(serial_type) => serial_type,
+            Err(e) => return Some(Err(e)),
         };
-
-        // Update header section to remove the consumed serial type
-        self.header_section.set(&header[bytes_read..]);
-
         let data_section = self.data_section.get();
-
         match read_value_serial_type(data_section, serial_type) {
             Ok((value, n)) => {
                 self.data_section.set(&data_section[n..]);
                 Some(Ok(value))
+            }
+            Err(e) => {
+                mark_unlikely();
+                Some(Err(e))
+            }
+        }
+    }
+}
+
+impl<'a> ValueIterator<'a> {
+    /// `next` without UTF-8 validation of TEXT.
+    #[inline(always)]
+    pub fn next_raw(&mut self) -> Option<Result<RawValueRef<'a>, LimboError>> {
+        let serial_type = match self.next_serial_type()? {
+            Ok(serial_type) => serial_type,
+            Err(e) => return Some(Err(e)),
+        };
+        let data_section = self.data_section.get();
+        match read_raw_value_serial_type(data_section, serial_type) {
+            Ok((value, n)) => {
+                self.data_section.set(&data_section[n..]);
+                Some(Ok(value))
+            }
+            Err(e) => {
+                mark_unlikely();
+                Some(Err(e))
+            }
+        }
+    }
+
+    /// Consumes the next serial type of the header.
+    #[inline(always)]
+    fn next_serial_type(&self) -> Option<Result<u64, LimboError>> {
+        let header = self.header_section.get();
+        if unlikely(header.is_empty()) {
+            return None;
+        }
+        match read_varint(header) {
+            Ok((serial_type, bytes_read)) => {
+                self.header_section.set(&header[bytes_read..]);
+                Some(Ok(serial_type))
             }
             Err(e) => {
                 mark_unlikely();
@@ -2622,11 +2685,27 @@ pub fn cmp_in_column(a: &ValueRef, b: &ValueRef, key: &KeyInfo) -> Ordering {
     cmp_with_sort(compare_immutable_single(a, b, key.collation), a, b, key)
 }
 
+/// `cmp_in_column` for values whose TEXT is still bytes. Two TEXT values under
+/// a byte-level collation compare without UTF-8 validation. Every other pair
+/// validates and takes the decoded path.
+pub fn cmp_raw_in_column(a: &RawValueRef, b: &RawValueRef, key: &KeyInfo) -> Result<Ordering> {
+    if let (RawValueRef::Text(left), RawValueRef::Text(right)) = (a, b) {
+        if let Some(cmp) = key.collation.compare_bytes(left, right) {
+            return Ok(sort_ordering(cmp, false, key));
+        }
+    }
+    Ok(cmp_in_column(&a.to_value_ref()?, &b.to_value_ref()?, key))
+}
+
 /// Outputs a modified [Ordering] that takes into account the sort order and the NULLS order.
 #[must_use]
 pub fn cmp_with_sort(cmp: Ordering, a: &ValueRef, b: &ValueRef, key: &KeyInfo) -> Ordering {
+    let involves_null = matches!(a, ValueRef::Null) || matches!(b, ValueRef::Null);
+    sort_ordering(cmp, involves_null, key)
+}
+
+fn sort_ordering(cmp: Ordering, involves_null: bool, key: &KeyInfo) -> Ordering {
     if cmp != Ordering::Equal {
-        let involves_null = matches!(a, ValueRef::Null) || matches!(b, ValueRef::Null);
         if involves_null {
             if let Some(nulls_order) = key.nulls_order {
                 // ValueRef ordering: NULL < non-NULL.
@@ -3785,6 +3864,41 @@ impl WalFrameInfo {
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn next_raw_yields_the_same_values_as_next() {
+        use super::*;
+
+        let values = [
+            ValueRef::Null,
+            ValueRef::from_i64(-7),
+            ValueRef::from_i64(1 << 40),
+            ValueRef::from_f64(1.5),
+            ValueRef::Text(TextRef::new("ascii", TextSubtype::Text)),
+            ValueRef::Text(TextRef::new("héllo wörld", TextSubtype::Text)),
+            ValueRef::Blob(&[0xff, 0x00, 0x80]),
+        ];
+        let record = ImmutableRecord::from_values(&values, values.len()).unwrap();
+        let mut decoded = record.iter().unwrap();
+        let mut raw = record.iter().unwrap();
+        for expected in &values {
+            let value = decoded.next().unwrap().unwrap();
+            let raw_value = raw.next_raw().unwrap().unwrap();
+            assert_eq!(&value, expected);
+            assert_eq!(raw_value.to_value_ref().unwrap(), value);
+        }
+        assert!(decoded.next().is_none());
+        assert!(raw.next_raw().is_none());
+    }
+
+    #[test]
+    fn raw_text_with_invalid_utf8_does_not_become_a_value_ref() {
+        use super::*;
+
+        let raw = RawValueRef::Text(&[0xff, 0xfe]);
+        assert!(matches!(raw.to_value_ref(), Err(LimboError::Corrupt(_))));
+        assert!(RawValueRef::Text("ok".as_bytes()).to_value_ref().is_ok());
+    }
+
     use super::*;
     use crate::alloc::vec;
     use crate::translate::collate::CollationSeq;


### PR DESCRIPTION
## Description

`SortableIndexKey::compare` decoded both index records on every comparison, and the decoder validated every TEXT value with `from_utf8`, because `TextRef` holds a `str`. A skiplist search compares one key many times, so the same few strings were validated millions of times.

Index keys now iterate with `ValueIterator::next_raw`, which leaves TEXT as bytes, and compare with `cmp_raw_in_column`. Two TEXT values under the BINARY, NOCASE, or RTRIM collations compare with `CollationSeq::compare_bytes`, the byte-level implementation that `compare_strings` uses too. Every other pair compares in the order that `ValueRef` uses. Only two TEXT values under a locale collation still decode. A TEXT key with invalid UTF-8 now compares by its bytes instead of failing. Reading the value still reports the corruption.

Two commits:

- `acfb07ac` adds the raw iterator, the byte-level collations, and the parity tests.
- `8c91323b` keeps the raw values out of memory. The first commit alone executed 4% fewer instructions under callgrind but needed 21% more CPU time per request. The `Option<Result<RawValueRef, LimboError>>` values of `next_raw` went through a tuple, the decoder returned its `Result` through memory, and the unaligned 16-byte loads that copied them back could not use store forwarding. A sampling profiler with instruction addresses found this. callgrind does not model the wait.

Measured on a mixed read and write load over MVCC with two secondary indexes, 300 requests under callgrind and three CPU-time rounds of 4,000 requests on 20,000 rows, against main `6b88d2b4`:

| Measure | main | this branch |
|---|---|---|
| Instructions, 300 requests | 4.50 G | 3.70 G, -17.8% |
| Instructions in turso_core | 2.90 G | 2.10 G, -27.5% |
| Data reads | 897 M | 718 M, -20.0% |
| Mispredicted conditional branches | 17.5 M | 14.4 M, -17.3% |
| CPU per request, mean of 3 rounds | 10.86 ms | 9.43 ms, -13.2% |

Tests: `compare_bytes` against the string comparison of each collation, `next_raw` against `next`, every pair of mixed-type two-column keys under three collations and both sort orders against `compare_immutable`, and invalid UTF-8 keys.

## Motivation and context

A CPU profile of the load above put `from_utf8` at 4.8% of the samples, with 98% of its calls from the index key comparison. The comparison group (`compare`, `read_value_serial_type`, `cmp_in_column`, `compare_immutable`, `ValueRef::cmp`) executed 2.36 G of the 4.50 G instructions of the window. It executes 1.56 G now. Two next steps remain: a comparison that never builds a `Result` for a valid value, and a key that caches its decoded record header.

## Description of AI Usage

Claude Code wrote the change, the tests, and the measurements, from a CPU profile and callgrind runs. The same session found the CPU-time regression of the first version and its cause with a sampling profiler and `objdump`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JWaypMzaeFgtUSoYzrwwnr

---
_Generated by [Claude Code](https://claude.ai/code/session_01JWaypMzaeFgtUSoYzrwwnr)_