### PR TITLE
core/translate: remove redundant marking last insn constant

### DIFF
--- a/core/translate/expr/functions.rs
+++ b/core/translate/expr/functions.rs
@@ -37,7 +37,6 @@ pub(super) fn translate_like_base(
                 }
             }
             if matches!(rhs.as_ref(), ast::Expr::Literal(_)) {
-                program.mark_last_insn_constant();
                 constant_mask = 1;
             }
             let func = match op {

--- a/sqlite/conformance/sqlite-sqltests/like.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/like.sqltest
@@ -380,6 +380,14 @@ expect error {
     ESCAPE expression must be a single character
 }
 
+test like-escape-column {
+    WITH t(s, p, e) AS (VALUES('a','a','#'))
+    SELECT s LIKE 'a' ESCAPE e FROM t;
+}
+expect {
+    1
+}
+
 test like-perf {
     SELECT 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' LIKE '%a%a%a%a%a%a%a%a%a%a%a%a%a%a%a%a%a%a%a%a%a%a%a%a%a%a%a%a%a%b';
 }


### PR DESCRIPTION
If `LIKE` has non-lit `ESCAPE` expr last insn is column that is marked as const. Therefore, `emit_constant_insns` function places erroneous const after `Transaction` insn, which leads to panic.
If `LIKE` has not `ESCAPE` expr, then unnecessary mark last insn as const because it has already been marked in `translate_expr`.

Closes #8716.