### PR TITLE
core/mvcc: reject conflicting deletes of B-tree rows at statement time

### DIFF
--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -5644,6 +5644,10 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                             .ok_or_else(|| LimboError::NoSuchTransactionID(tx_id.to_string()))?;
                         let tx = tx.value();
                         turso_assert_eq!(tx.state, TransactionState::Active);
+                        if is_btree_tombstone_conflict(&self.txs, &self.finalized_tx_states, tx, rv)
+                        {
+                            return Err(LimboError::WriteWriteConflict);
+                        }
                         // A transaction cannot delete a version that it cannot see,
                         // nor can it conflict with it.
                         if !rv.is_visible_to(tx, &self.txs, &self.finalized_tx_states) {
@@ -5680,6 +5684,10 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                             .ok_or_else(|| LimboError::NoSuchTransactionID(tx_id.to_string()))?;
                         let tx = tx.value();
                         turso_assert_eq!(tx.state, TransactionState::Active);
+                        if is_btree_tombstone_conflict(&self.txs, &self.finalized_tx_states, tx, rv)
+                        {
+                            return Err(LimboError::WriteWriteConflict);
+                        }
                         // A transaction cannot delete a version that it cannot see,
                         // nor can it conflict with it.
                         if !rv.is_visible_to(tx, &self.txs, &self.finalized_tx_states) {
@@ -10540,6 +10548,22 @@ fn is_write_write_conflict<A: ConcurrentAllocator>(
         // Ref: https://www.cs.cmu.edu/~15721-f24/papers/Hekaton.pdf , page 301,
         // 2.6. Updating a Version.
         Some(TxTimestampOrID::Timestamp(_)) => true,
+        None => false,
+    }
+}
+
+fn is_btree_tombstone_conflict<A: ConcurrentAllocator>(
+    txs: &SkipMap<TxID, Transaction<A>, BasicComparator, A>,
+    finalized_tx_states: &SkipMap<TxID, TransactionState, BasicComparator, A>,
+    tx: &Transaction<A>,
+    rv: &RowVersion,
+) -> bool {
+    if rv.begin().is_some() {
+        return false;
+    }
+    match rv.end() {
+        Some(TxTimestampOrID::Timestamp(end_ts)) => end_ts > tx.begin_ts,
+        Some(TxTimestampOrID::TxID(_)) => is_write_write_conflict(txs, finalized_tx_states, tx, rv),
         None => false,
     }
 }

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -5644,18 +5644,15 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                             .ok_or_else(|| LimboError::NoSuchTransactionID(tx_id.to_string()))?;
                         let tx = tx.value();
                         turso_assert_eq!(tx.state, TransactionState::Active);
-                        if is_btree_tombstone_conflict(&self.txs, &self.finalized_tx_states, tx, rv)
+                        let visible = rv.is_visible_to(tx, &self.txs, &self.finalized_tx_states);
+                        if (visible || rv.begin().is_none())
+                            && is_write_write_conflict(&self.txs, &self.finalized_tx_states, tx, rv)
                         {
-                            return Err(LimboError::WriteWriteConflict);
-                        }
-                        // A transaction cannot delete a version that it cannot see,
-                        // nor can it conflict with it.
-                        if !rv.is_visible_to(tx, &self.txs, &self.finalized_tx_states) {
-                            continue;
-                        }
-                        if is_write_write_conflict(&self.txs, &self.finalized_tx_states, tx, rv) {
                             turso_assert_reachable!("write-write conflict on delete");
                             return Err(LimboError::WriteWriteConflict);
+                        }
+                        if !visible {
+                            continue;
                         }
 
                         let version_id = rv.id;
@@ -5684,18 +5681,15 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                             .ok_or_else(|| LimboError::NoSuchTransactionID(tx_id.to_string()))?;
                         let tx = tx.value();
                         turso_assert_eq!(tx.state, TransactionState::Active);
-                        if is_btree_tombstone_conflict(&self.txs, &self.finalized_tx_states, tx, rv)
+                        let visible = rv.is_visible_to(tx, &self.txs, &self.finalized_tx_states);
+                        if (visible || rv.begin().is_none())
+                            && is_write_write_conflict(&self.txs, &self.finalized_tx_states, tx, rv)
                         {
-                            return Err(LimboError::WriteWriteConflict);
-                        }
-                        // A transaction cannot delete a version that it cannot see,
-                        // nor can it conflict with it.
-                        if !rv.is_visible_to(tx, &self.txs, &self.finalized_tx_states) {
-                            continue;
-                        }
-                        if is_write_write_conflict(&self.txs, &self.finalized_tx_states, tx, rv) {
                             turso_assert_reachable!("write-write conflict on delete");
                             return Err(LimboError::WriteWriteConflict);
+                        }
+                        if !visible {
+                            continue;
                         }
 
                         let version_id = rv.id;
@@ -10543,27 +10537,7 @@ fn is_write_write_conflict<A: ConcurrentAllocator>(
                 }
             }
         }
-        // A non-"infinity" end timestamp (here modeled by Some(ts)) functions as a write lock
-        // on the row, so it can never be updated by another transaction.
-        // Ref: https://www.cs.cmu.edu/~15721-f24/papers/Hekaton.pdf , page 301,
-        // 2.6. Updating a Version.
-        Some(TxTimestampOrID::Timestamp(_)) => true,
-        None => false,
-    }
-}
-
-fn is_btree_tombstone_conflict<A: ConcurrentAllocator>(
-    txs: &SkipMap<TxID, Transaction<A>, BasicComparator, A>,
-    finalized_tx_states: &SkipMap<TxID, TransactionState, BasicComparator, A>,
-    tx: &Transaction<A>,
-    rv: &RowVersion,
-) -> bool {
-    if rv.begin().is_some() {
-        return false;
-    }
-    match rv.end() {
         Some(TxTimestampOrID::Timestamp(end_ts)) => end_ts > tx.begin_ts,
-        Some(TxTimestampOrID::TxID(_)) => is_write_write_conflict(txs, finalized_tx_states, tx, rv),
         None => false,
     }
 }

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -5644,6 +5644,9 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                             .ok_or_else(|| LimboError::NoSuchTransactionID(tx_id.to_string()))?;
                         let tx = tx.value();
                         turso_assert_eq!(tx.state, TransactionState::Active);
+                        // A transaction cannot delete a version that it cannot see.
+                        // B-tree deletion markers are not visible versions, but their
+                        // end fields can still indicate a write-write conflict.
                         let visible = rv.is_visible_to(tx, &self.txs, &self.finalized_tx_states);
                         if (visible || rv.begin().is_none())
                             && is_write_write_conflict(&self.txs, &self.finalized_tx_states, tx, rv)
@@ -5681,6 +5684,9 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                             .ok_or_else(|| LimboError::NoSuchTransactionID(tx_id.to_string()))?;
                         let tx = tx.value();
                         turso_assert_eq!(tx.state, TransactionState::Active);
+                        // A transaction cannot delete a version that it cannot see.
+                        // B-tree deletion markers are not visible versions, but their
+                        // end fields can still indicate a write-write conflict.
                         let visible = rv.is_visible_to(tx, &self.txs, &self.finalized_tx_states);
                         if (visible || rv.begin().is_none())
                             && is_write_write_conflict(&self.txs, &self.finalized_tx_states, tx, rv)
@@ -10537,6 +10543,12 @@ fn is_write_write_conflict<A: ConcurrentAllocator>(
                 }
             }
         }
+        // A non-"infinity" end timestamp (here modeled by Some(ts)) functions as a write lock
+        // on the row version, so it cannot be updated by another transaction that still sees it.
+        // Ref: https://www.cs.cmu.edu/~15721-f24/papers/Hekaton.pdf , page 301,
+        // 2.6. Updating a Version.
+        // B-tree deletion markers also reach this check. A deletion committed before
+        // our snapshot does not conflict; one committed after our snapshot does.
         Some(TxTimestampOrID::Timestamp(end_ts)) => end_ts > tx.begin_ts,
         None => false,
     }

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -10146,7 +10146,8 @@ fn test_rollback_with_index() {
     assert_eq!(&rows[0][0].to_string(), "ok");
 }
 
-fn try_idxdelete_during_preparing_corruption() -> Option<String> {
+#[test]
+fn test_stale_update_of_deleted_row_is_refused_before_it_can_corrupt_indexes() {
     let db = MvccTestDbNoConn::new_with_random_db();
     let setup = db.connect();
     setup.execute("PRAGMA page_size = 512").unwrap();
@@ -10193,7 +10194,6 @@ fn try_idxdelete_during_preparing_corruption() -> Option<String> {
 
     let old = db.connect();
     let deleter = db.connect();
-    let victim = db.connect();
 
     old.execute("BEGIN CONCURRENT").unwrap();
     let _ = get_rows(&old, "SELECT COUNT(*) FROM t WHERE id = 322");
@@ -10211,89 +10211,25 @@ fn try_idxdelete_during_preparing_corruption() -> Option<String> {
         ))
         .unwrap();
     }
-    old.execute(
+    let stale_update = old.execute(
         "UPDATE t SET a = 179, b = 7.75, blob = zeroblob(4194304), c = 453, u = 'hot_hill_935', d = 5.05 WHERE id = 322",
-    )
-    .unwrap();
+    );
+    assert!(
+        matches!(stale_update, Err(LimboError::WriteWriteConflict)),
+        "stale updater must lose to the committed delete at the statement, got {stale_update:?}"
+    );
+    assert!(old.get_auto_commit());
 
-    let mv_store = db.get_mvcc_store();
-    let old_tx_id = old.get_mv_tx_id().expect("old txn should be active");
-    old.set_yield_injector(Some(FixedYieldInjector::new([
-        CommitYieldPoint::CommitValidation.point(),
-    ])));
-
-    let (at_preparing_tx, at_preparing_rx) = std::sync::mpsc::channel();
-    let (proceed_tx, proceed_rx) = std::sync::mpsc::channel();
-
-    let commit_handle = std::thread::spawn(move || {
-        let mut commit = old.prepare("COMMIT").unwrap();
-        match commit.step().unwrap() {
-            crate::StepResult::Yield => {}
-            other => panic!("old COMMIT should yield at CommitValidation, got {other:?}"),
-        }
-        at_preparing_tx.send(()).unwrap();
-        proceed_rx.recv().unwrap();
-        commit.run_ignore_rows()
-    });
-
-    at_preparing_rx.recv().unwrap();
-
-    let saw_preparing = mv_store
-        .txs
-        .get(&old_tx_id)
-        .is_some_and(|entry| matches!(entry.value().state.load(), TransactionState::Preparing(_)));
-
+    let victim = db.connect();
     victim.execute("BEGIN CONCURRENT").unwrap();
     let victim_delete = victim.execute("DELETE FROM t WHERE id = 322");
-    proceed_tx.send(()).unwrap();
-    let old_commit = commit_handle.join().unwrap();
-    let _ = victim.execute("ROLLBACK");
-
-    if let Err(LimboError::Corrupt(msg)) = victim_delete {
-        return Some(msg);
-    }
-
-    match victim_delete {
-        Ok(_)
-        | Err(LimboError::WriteWriteConflict)
-        | Err(LimboError::Busy)
-        | Err(LimboError::BusySnapshot)
-        | Err(LimboError::CommitDependencyAborted) => {}
-        other => panic!("unexpected victim DELETE result: {other:?}"),
-    }
-
     assert!(
-        saw_preparing,
-        "old txn should reach Preparing during COMMIT"
+        victim_delete.is_ok(),
+        "a delete of an already deleted row matches nothing, got {victim_delete:?}"
     );
-    assert!(
-        matches!(old_commit, Err(LimboError::WriteWriteConflict)),
-        "stale updater should lose to concurrent delete, got {old_commit:?}"
-    );
+    victim.execute("COMMIT").unwrap();
 
     assert_integrity_ok(&db.connect());
-    None
-}
-
-/// Concurrent DELETE while another txn is committing an UPDATE on a row that a
-/// third txn already deleted must not corrupt unique indexes.
-///
-/// Sequence (from idxdelete_speculative_abort_repro):
-/// 1. `old` begins and pins a snapshot containing row 322.
-/// 2. `deleter` autocommits DELETE of row 322 (MVCC delete; btree unchanged with
-///    checkpoint disabled).
-/// 3. `old` updates row 322 anyway (stale snapshot), rewriting unique columns.
-/// 4. `old` enters `Preparing` during COMMIT.
-/// 5. `victim` DELETEs row 322: table cursor reads `old`'s new unique values, but
-///    IdxDelete cannot find those keys in the btree/MVCC index → corruption.
-#[test]
-fn test_delete_during_preparing_update_of_stale_deleted_row_no_idxdelete_corruption() {
-    const ATTEMPTS: usize = 20;
-    for attempt in 0..ATTEMPTS {
-        if let Some(msg) = try_idxdelete_during_preparing_corruption() {
-            panic!("DELETE corrupted indexes on attempt {attempt}: {msg}");
-        }
-    }
 }
 
 /// 1. BEGIN CONCURRENT (start interactive transaction)
@@ -15433,13 +15369,6 @@ fn test_partial_commit_visibility_bug() {
     }
 }
 
-/// Two concurrent transactions delete the same B-tree-resident row that has a
-/// UNIQUE index. Both DELETEs succeed at execute time because tombstones
-/// (begin: None) are invisible to is_visible_to(), so both transactions
-/// create independent tombstones. However, commit-time validation in
-/// check_version_conflicts detects the other transaction's tombstone as a
-/// write lock (via its end: TxID field) and rejects the second committer
-/// with WriteWriteConflict.
 #[test]
 fn test_double_delete_btree_resident_row_with_unique_index() {
     let db = MvccTestDbNoConn::new_with_random_db();
@@ -15464,21 +15393,13 @@ fn test_double_delete_btree_resident_row_with_unique_index() {
     // T1 deletes row 1 — creates tombstone (begin: None, end: TxID(T1))
     conn1.execute("DELETE FROM t WHERE id = 1").unwrap();
 
-    // T2 deletes the same row — creates a second tombstone at execute time
-    // (is_visible_to still returns false for tombstones, so operation-time
-    // conflict detection is bypassed — that's a separate issue)
-    conn2.execute("DELETE FROM t WHERE id = 1").unwrap();
+    let err = conn2
+        .execute("DELETE FROM t WHERE id = 1")
+        .expect_err("T2's DELETE must fail while T1 holds a tombstone for the same row");
+    assert!(matches!(err, LimboError::WriteWriteConflict), "{err:?}");
 
     // T1 commits first — stamps its tombstones with Timestamp
     conn1.execute("COMMIT").unwrap();
-
-    // T2's commit should fail: check_version_conflicts now detects T1's
-    // committed tombstone (end: Timestamp >= T2.begin_ts)
-    assert!(
-        conn2.execute("COMMIT").is_err(),
-        "T2's COMMIT should fail with WriteWriteConflict when T1 already \
-         committed a tombstone for the same row"
-    );
     drop(conn1);
     drop(conn2);
 
@@ -19113,6 +19034,92 @@ fn test_explicit_delete_conflicts_with_concurrent_delete_without_replacing_marke
 
     concurrent.execute("COMMIT").unwrap();
     let rows = get_rows(&exclusive, "SELECT id, text FROM t ORDER BY id");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0][0].as_int().unwrap(), 2);
+}
+
+#[test]
+fn test_delete_of_btree_row_conflicts_with_committed_concurrent_delete() {
+    let db = MvccTestDbNoConn::new_with_random_db();
+    let setup = db.connect();
+    setup
+        .execute("PRAGMA mvcc_checkpoint_threshold = 0")
+        .unwrap();
+    setup
+        .execute("CREATE TABLE t(id INTEGER PRIMARY KEY, text TEXT)")
+        .unwrap();
+    setup
+        .execute("INSERT INTO t VALUES(1, 'original'), (2, 'keep')")
+        .unwrap();
+    let store = db.get_mvcc_store();
+    let root_page = get_rows(
+        &setup,
+        "SELECT rootpage FROM sqlite_schema WHERE name = 't'",
+    )[0][0]
+        .as_int()
+        .unwrap();
+    let row_id = RowID::new(store.get_table_id_from_root_page(root_page), RowKey::Int(1));
+    assert!(
+        store.rows.get(&row_id).is_none(),
+        "the row must live only in the B-tree for this test to mean anything"
+    );
+    setup.close().unwrap();
+
+    let stale = db.connect();
+    let deleter = db.connect();
+    stale.execute("BEGIN CONCURRENT").unwrap();
+    assert_eq!(get_rows(&stale, "SELECT id FROM t ORDER BY id").len(), 2);
+    deleter.execute("DELETE FROM t WHERE id = 1").unwrap();
+
+    let err = stale
+        .execute("DELETE FROM t WHERE id = 1")
+        .expect_err("a delete of a row another transaction already deleted must conflict");
+    assert!(matches!(err, LimboError::WriteWriteConflict), "{err:?}");
+    assert!(stale.get_auto_commit());
+
+    let rows = get_rows(&deleter, "SELECT id FROM t ORDER BY id");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0][0].as_int().unwrap(), 2);
+}
+
+#[test]
+fn test_delete_of_btree_row_conflicts_with_active_concurrent_delete() {
+    let db = MvccTestDbNoConn::new_with_random_db();
+    let setup = db.connect();
+    setup
+        .execute("PRAGMA mvcc_checkpoint_threshold = 0")
+        .unwrap();
+    setup
+        .execute("CREATE TABLE t(id INTEGER PRIMARY KEY, text TEXT)")
+        .unwrap();
+    setup
+        .execute("INSERT INTO t VALUES(1, 'original'), (2, 'keep')")
+        .unwrap();
+    let store = db.get_mvcc_store();
+    let root_page = get_rows(
+        &setup,
+        "SELECT rootpage FROM sqlite_schema WHERE name = 't'",
+    )[0][0]
+        .as_int()
+        .unwrap();
+    let row_id = RowID::new(store.get_table_id_from_root_page(root_page), RowKey::Int(1));
+    assert!(store.rows.get(&row_id).is_none());
+    setup.close().unwrap();
+
+    let first = db.connect();
+    let second = db.connect();
+    first.execute("BEGIN CONCURRENT").unwrap();
+    first.execute("DELETE FROM t WHERE id = 1").unwrap();
+
+    second.execute("BEGIN CONCURRENT").unwrap();
+    let err = second
+        .execute("DELETE FROM t WHERE id = 1")
+        .expect_err("a delete of a row another open transaction deleted must conflict");
+    assert!(matches!(err, LimboError::WriteWriteConflict), "{err:?}");
+    assert!(second.get_auto_commit());
+
+    first.execute("COMMIT").unwrap();
+    let rows = get_rows(&second, "SELECT id FROM t ORDER BY id");
     assert_eq!(rows.len(), 1);
     assert_eq!(rows[0][0].as_int().unwrap(), 2);
 }


### PR DESCRIPTION
## Why

Extract the MVCC engine fix from #8940 so it can be reviewed and merged independently. This PR targets main and does not depend on #8917. It does not change FTS merge behavior or remove the merge lease. The original PR is unchanged.

**An old transaction may still read a deleted row. But it must not delete that row again without detecting the other transaction’s change.**

A transaction reads a snapshot: the database as it looked when that transaction started. Even if another transaction deletes a row, an older transaction may still see it. Reading that old row is allowed. Deleting it again must detect the conflicting write.

### Example: two transactions delete row 7

```text
        Transaction A                   Transaction B
        ┌────────────────┐              ┌────────────────┐
        │ Sees row 7     │              │ Sees row 7     │
        └───────┬────────┘              └───────┬────────┘
                │                               │
                ▼                               │
        ┌────────────────┐                      │
        │ Deletes row 7  │                      │
        └───────┬────────┘                      │
                │                               │
                ▼                               │
        ┌─────────────────────┐                 │
        │ Turso records:      │                 │
        │ “A deleted row 7”   │                 │
        └─────────────────────┘                 │
                                                ▼
                                  ┌─────────────────────────┐
                                  │ B still sees row 7 in   │
                                  │ its older snapshot.     │
                                  │ B tries to delete it.   │
                                  └────────────┬────────────┘
                                               │
                           ┌───────────────────┴──────────────────┐
                           ▼                                      ▼
                ┌─────────────────────┐              ┌─────────────────────┐
                │ BEFORE              │              │ AFTER               │
                │ Skip the marker.    │              │ Check the marker.   │
                │ Accept the delete.  │              │ Reject the delete.  │
                └─────────────────────┘              └─────────────────────┘
```

### Why the old code missed it

Turso does not immediately erase the stored row when A deletes it. It records a deletion marker. For a row stored only in the B-tree—the database’s main row storage—its first deletion marker looks roughly like this:

| Information | Value | Meaning |
|---|---|---|
| Row | `7` | Which row was deleted |
| Creation timestamp | None | This marker does not represent a newly created row |
| Deleted by | Transaction A | A has deleted the stored row |

The old code treated **“not a visible row version”** as a reason to skip the marker entirely. But the marker still mattered for deciding whether another write was allowed.

| Step | Before the fix | After the fix |
|---|---|---|
| B finds the deletion marker from A | Checks whether it is visible as a row | First checks whether it represents a conflicting delete |
| Marker has no creation timestamp | Skips it | Still examines who deleted the row and when |
| A is still active | The delete from B can incorrectly succeed | B gets `WriteWriteConflict` |
| A committed after the snapshot of B began | The delete from B can incorrectly succeed | B gets `WriteWriteConflict` |
| B only reads the old row | Allowed by its snapshot | Still allowed |

### Why detecting it early matters

| Row being deleted | Before the fix | With the fix |
|---|---|---|
| Ordinary table row | A later commit check could catch the conflict | The conflicting `DELETE` fails immediately |
| Non-unique index row | No equivalent commit check caught this case | The conflicting delete fails immediately |
| FTS segment registry row | Without the merge lease, two merges could replace the same segment, duplicating search results | The second merge’s registry-row delete detects the conflict |

**This MVCC PR supplies the conflict error. The separate FTS PR #8940 uses that error to skip the segment instead of failing the merge.** The existing FTS merge lease stays in place in this PR.

## Change

Keep B-tree deletion markers at `begin: None`. Compute row visibility, then send both visible MVCC versions and B-tree deletion markers through the existing `is_write_write_conflict` check before skipping invisible entries. The shared check compares committed deletion timestamps against the transaction snapshot. Remove the separate B-tree conflict helper; do not change which versions readers can see.

Include the two regression tests from #8940 for active and committed concurrent deletes. Update two existing tests to expect the stale DELETE or UPDATE to fail during the statement rather than at commit. Preserve the source commit author.

## Verification

Current revision:

- `cargo test -p turso_core --lib mvcc::database::tests`: 395 passed, 1 failed, 6 ignored. All four delete/update regression tests pass.
- The failing test is `test_conflict_abort_ckpt_indexed_update_savepoint_integrity_check_passive`. In this run it reported `row 91 missing from index sqlite_autoindex_t_1` during a concurrent integrity check. This is unresolved; the suite is not passing.
- `cargo fmt --check` and `git diff --check`: passed.

Earlier verification, before consolidating the helpers:

- Both new regression tests failed without the engine fix because the second DELETE incorrectly succeeded.
- The MVCC suite passed once with 396 passed and 6 ignored. The full serial core suite passed once with 2,435 passed and 17 ignored.
- CI subsequently failed the passive-checkpoint stress test on macOS and in conn-raw-api-tests, with `index finger diverged from query_btree_version_is_valid`. That failure was also reproduced locally.
- A full parallel core run also aborted in `attached_reader_does_not_pin_read_mark_until_checkpoint_gate_is_available`: it expected Busy but received a row, then panicked during cleanup. That test passed alone and in the serial run.

The causes of these concurrency failures have not been established. Earlier successful runs do not establish that the PR is free of these failures.

