### PR TITLE
core/translate: apply ADD COLUMN DEFAULT type check to STRICT tables only

### DIFF
--- a/core/translate/alter.rs
+++ b/core/translate/alter.rs
@@ -1328,7 +1328,10 @@ pub fn translate_alter_table(
                     }
                 }
 
-                default_type_mismatch = strict_default_type_mismatch(&column)?;
+                // The DEFAULT type check belongs to STRICT tables only: on an
+                // ordinary table the declared type is only an affinity, so any
+                // constant default is accepted there.
+                default_type_mismatch = btree.is_strict && strict_default_type_mismatch(&column)?;
             }
 
             // If a column has no explicit DEFAULT but its custom type defines

--- a/tests/integration/query_processing/test_alter_table_reopen.rs
+++ b/tests/integration/query_processing/test_alter_table_reopen.rs
@@ -263,3 +263,59 @@ fn test_alter_table_add_column_preserves_collation_on_reopen() {
         conn.close().unwrap();
     }
 }
+
+/// ADD COLUMN must only apply the STRICT DEFAULT type check to STRICT tables.
+/// On an ordinary table the declared type is just an affinity, so SQLite
+/// accepts any constant default; the check used to run there too, and only
+/// once the table held a row, so the same migration passed while empty.
+/// See https://github.com/tursodatabase/turso/issues/8763
+#[test]
+fn test_alter_add_column_default_type_check_is_strict_only() {
+    let tmp_db = TempDatabase::new_empty();
+    let conn = tmp_db.connect_limbo();
+
+    conn.execute("CREATE TABLE t(a INTEGER)").unwrap();
+    conn.execute("INSERT INTO t VALUES(1)").unwrap();
+
+    // A BLOB default on a non-STRICT table that already holds a row.
+    conn.execute("ALTER TABLE t ADD COLUMN b BLOB DEFAULT ''")
+        .unwrap();
+    let rows: Vec<(String,)> = conn.exec_rows("SELECT quote(b) FROM t");
+    assert_eq!(rows, vec![("''".to_string(),)]);
+
+    // INT, REAL and TEXT reach the same check, so it is not about BLOB.
+    conn.execute("ALTER TABLE t ADD COLUMN c INTEGER DEFAULT 3.7")
+        .unwrap();
+    let rows: Vec<(f64,)> = conn.exec_rows("SELECT c FROM t");
+    assert_eq!(rows, vec![(3.7,)]);
+
+    conn.execute("ALTER TABLE t ADD COLUMN d TEXT DEFAULT 5")
+        .unwrap();
+    let rows: Vec<(String,)> = conn.exec_rows("SELECT quote(d) FROM t");
+    assert_eq!(rows, vec![("'5'".to_string(),)]);
+}
+
+/// The same check must still reject a mistyped default on a STRICT table,
+/// whether or not the table holds a row.
+#[test]
+fn test_alter_add_column_default_type_check_still_guards_strict_tables() {
+    let tmp_db = TempDatabase::new_empty();
+    let conn = tmp_db.connect_limbo();
+
+    conn.execute("CREATE TABLE v(a INTEGER) STRICT").unwrap();
+    conn.execute("INSERT INTO v VALUES(1)").unwrap();
+
+    let err = conn
+        .execute("ALTER TABLE v ADD COLUMN b BLOB DEFAULT ''")
+        .expect_err("STRICT table must reject a mistyped DEFAULT");
+    assert!(
+        err.to_string().contains("type mismatch on DEFAULT"),
+        "unexpected error: {err}"
+    );
+
+    // A default of the declared type is still accepted.
+    conn.execute("ALTER TABLE v ADD COLUMN c TEXT DEFAULT 'x'")
+        .unwrap();
+    let rows: Vec<(String,)> = conn.exec_rows("SELECT c FROM v");
+    assert_eq!(rows, vec![("x".to_string(),)]);
+}


### PR DESCRIPTION
## Problem

Per #8763, `ALTER TABLE ADD COLUMN` refuses an ordinary `BLOB DEFAULT ''` on a table that is not STRICT, but only once that table holds a row:

```sql
CREATE TABLE t(a INTEGER);
INSERT INTO t VALUES(1);
ALTER TABLE t ADD COLUMN b BLOB DEFAULT '';
-- Turso:  type mismatch on DEFAULT, then no such column: b
-- SQLite: ''
```

## Cause

`strict_default_type_mismatch` checks a constant DEFAULT against the column's declared type. That rule belongs to STRICT tables, where the declared type is enforced. On an ordinary table the type is only an affinity, so SQLite accepts any constant default.

The call site ran it unconditionally:

```rust
default_type_mismatch = strict_default_type_mismatch(&column)?;
```

Every neighbouring branch in the same block guards on `btree.is_strict`; this one did not. The resulting check is emitted behind `Rewind { pc_if_empty }`, which is why an empty table passed the same migration and a populated one failed.

## Fix

Guard the check with `btree.is_strict`, so it applies where the declared type is actually enforced.

## Verification

`tursodb` built from this branch against `sqlite3`, same SQL to both:

| case | sqlite | turso |
|---|---|---|
| non-STRICT, has row, `BLOB DEFAULT ''` | `''` | `''` |
| non-STRICT, has row, `INTEGER DEFAULT 3.7` | `3.7` | `3.7` |
| non-STRICT, has row, `TEXT DEFAULT 5` | `'5'` | `'5'` |
| non-STRICT, empty table | `2` | `2` |
| STRICT, has row, `BLOB DEFAULT ''` | `type mismatch on DEFAULT` | `type mismatch on DEFAULT` |
| STRICT, empty table | `2` | `2` |
| STRICT, valid `TEXT DEFAULT 'x'` | `x` | `x` |

## Tests

Two tests in `tests/integration/query_processing/test_alter_table_reopen.rs`:

- `test_alter_add_column_default_type_check_is_strict_only` — BLOB, INTEGER and TEXT defaults on a populated non-STRICT table
- `test_alter_add_column_default_type_check_still_guards_strict_tables` — a STRICT table still rejects a mistyped default and still accepts a correctly typed one

```
test result: ok. 2 passed; 0 failed
```

`cargo fmt --all -- --check` is clean.

Closes #8763
