### PR TITLE
core/numeric: match SQLite exponent limits and float rounding

### DIFF
--- a/core/numeric/mod.rs
+++ b/core/numeric/mod.rs
@@ -657,7 +657,7 @@ pub fn str_to_f64(input: impl AsRef<str>) -> Option<StrToF64> {
             let mut e = 0;
 
             while let Some(ch) = input.next_if(char::is_ascii_digit) {
-                e = (e * 10 + ch.to_digit(10).unwrap() as i32).min(1000);
+                e = (e * 10 + ch.to_digit(10).unwrap() as i32).min(10000);
             }
 
             exponent += sign * e;
@@ -924,6 +924,14 @@ pub fn format_float_for_quote(v: f64) -> String {
         return default;
     }
     format_float_scientific(v, 19)
+}
+
+#[test]
+fn str_to_f64_uses_sqlite_exponent_limit() {
+    let text = format!(".{}1e10000", "0".repeat(700));
+    let value = str_to_f64(text).map(f64::from);
+
+    assert_eq!(value, Some(f64::INFINITY));
 }
 
 #[test]

--- a/core/numeric/mod.rs
+++ b/core/numeric/mod.rs
@@ -606,16 +606,12 @@ pub fn str_to_f64(input: impl AsRef<str>) -> Option<StrToF64> {
     // Copy as many significant digits as we can
     while let Some(digit) = input.peek().and_then(|ch| ch.to_digit(10)) {
         had_digits = true;
-
-        match significant
-            .checked_mul(10)
-            .and_then(|v| v.checked_add(digit as u64))
-        {
-            Some(new) => significant = new,
-            None => break,
-        }
-
+        significant = significant * 10 + digit as u64;
         input.next();
+
+        if significant >= (u64::MAX - 9) / 10 {
+            break;
+        }
     }
 
     let mut exponent = 0;
@@ -932,6 +928,13 @@ fn str_to_f64_uses_sqlite_exponent_limit() {
     let value = str_to_f64(text).map(f64::from);
 
     assert_eq!(value, Some(f64::INFINITY));
+}
+
+#[test]
+fn str_to_f64_matches_sqlite_near_u64_max() {
+    let value = str_to_f64("18446744073709551613E-298").map(f64::from);
+
+    assert_eq!(value, Some(1.8446744073709554e-279));
 }
 
 #[test]


### PR DESCRIPTION
## Description
Fix two SQLite compatibility issues in `str_to_f64`, with a separate commit and regression test for each.

## Motivation and context
Turso could parse the same numeric text differently from SQLite in two cases:
1.  Exponents were capped at `1000` instead of SQLite's `10000`. With enough leading fractional zeroes, this produced a finite value where SQLite returns infinity. Use SQLite's exponent limit.
2. Integer digits were accumulated as long as they fit in `u64`. Near `u64::MAX`, converting that integer to `f64` before decimal scaling introduced a rounding difference. Use SQLite's significand threshold and account for the remaining digits in the decimal exponent.

The regression tests cover:
-  A decimal point followed by 700 zeroes and `1e10000`, which must produce positive infinity.
- `18446744073709551613E-298`, which must round to `1.8446744073709554e-279`.

## Validation
Full project test suite.

## Description of AI Usage
I used OpenAI codex with GPT-5.6 as a code reviewer for ensuring accuracy when converting the fuzz crash artefacts into regression tests, and while authoring the patches.