### PR TITLE
build: Gate advapi32 link on the target OS, not the host

### DIFF
--- a/extensions/completion/build.rs
+++ b/extensions/completion/build.rs
@@ -1,9 +1,4 @@
 fn main() {
-    // Gate on the *build target* OS, not the host: cfg!() in a build script
-    // evaluates against the host, so cross-compiling this crate from a
-    // Windows machine to any other target injected the Windows-only
-    // advapi32 link flag into the target and failed the link with
-    // "unable to find library -ladvapi32".
     if std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("windows") {
         println!("cargo:rustc-link-lib=advapi32");
     }

--- a/extensions/completion/build.rs
+++ b/extensions/completion/build.rs
@@ -1,5 +1,10 @@
 fn main() {
-    if cfg!(target_os = "windows") {
+    // Gate on the *build target* OS, not the host: cfg!() in a build script
+    // evaluates against the host, so cross-compiling this crate from a
+    // Windows machine to any other target injected the Windows-only
+    // advapi32 link flag into the target and failed the link with
+    // "unable to find library -ladvapi32".
+    if std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("windows") {
         println!("cargo:rustc-link-lib=advapi32");
     }
 }

--- a/extensions/core/build.rs
+++ b/extensions/core/build.rs
@@ -1,9 +1,4 @@
 fn main() {
-    // Gate on the *build target* OS, not the host: cfg!() in a build script
-    // evaluates against the host, so cross-compiling this crate from a
-    // Windows machine to any other target injected the Windows-only
-    // advapi32 link flag into the target and failed the link with
-    // "unable to find library -ladvapi32".
     if std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("windows") {
         println!("cargo:rustc-link-lib=advapi32");
     }

--- a/extensions/core/build.rs
+++ b/extensions/core/build.rs
@@ -1,5 +1,10 @@
 fn main() {
-    if cfg!(target_os = "windows") {
+    // Gate on the *build target* OS, not the host: cfg!() in a build script
+    // evaluates against the host, so cross-compiling this crate from a
+    // Windows machine to any other target injected the Windows-only
+    // advapi32 link flag into the target and failed the link with
+    // "unable to find library -ladvapi32".
+    if std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("windows") {
         println!("cargo:rustc-link-lib=advapi32");
     }
 }

--- a/extensions/crypto/build.rs
+++ b/extensions/crypto/build.rs
@@ -1,9 +1,4 @@
 fn main() {
-    // Gate on the *build target* OS, not the host: cfg!() in a build script
-    // evaluates against the host, so cross-compiling this crate from a
-    // Windows machine to any other target injected the Windows-only
-    // advapi32 link flag into the target and failed the link with
-    // "unable to find library -ladvapi32".
     if std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("windows") {
         println!("cargo:rustc-link-lib=advapi32");
     }

--- a/extensions/crypto/build.rs
+++ b/extensions/crypto/build.rs
@@ -1,5 +1,10 @@
 fn main() {
-    if cfg!(target_os = "windows") {
+    // Gate on the *build target* OS, not the host: cfg!() in a build script
+    // evaluates against the host, so cross-compiling this crate from a
+    // Windows machine to any other target injected the Windows-only
+    // advapi32 link flag into the target and failed the link with
+    // "unable to find library -ladvapi32".
+    if std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("windows") {
         println!("cargo:rustc-link-lib=advapi32");
     }
 }

--- a/extensions/csv/build.rs
+++ b/extensions/csv/build.rs
@@ -1,9 +1,4 @@
 fn main() {
-    // Gate on the *build target* OS, not the host: cfg!() in a build script
-    // evaluates against the host, so cross-compiling this crate from a
-    // Windows machine to any other target injected the Windows-only
-    // advapi32 link flag into the target and failed the link with
-    // "unable to find library -ladvapi32".
     if std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("windows") {
         println!("cargo:rustc-link-lib=advapi32");
     }

--- a/extensions/csv/build.rs
+++ b/extensions/csv/build.rs
@@ -1,5 +1,10 @@
 fn main() {
-    if cfg!(target_os = "windows") {
+    // Gate on the *build target* OS, not the host: cfg!() in a build script
+    // evaluates against the host, so cross-compiling this crate from a
+    // Windows machine to any other target injected the Windows-only
+    // advapi32 link flag into the target and failed the link with
+    // "unable to find library -ladvapi32".
+    if std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("windows") {
         println!("cargo:rustc-link-lib=advapi32");
     }
 }

--- a/extensions/fuzzy/build.rs
+++ b/extensions/fuzzy/build.rs
@@ -1,9 +1,4 @@
 fn main() {
-    // Gate on the *build target* OS, not the host: cfg!() in a build script
-    // evaluates against the host, so cross-compiling this crate from a
-    // Windows machine to any other target injected the Windows-only
-    // advapi32 link flag into the target and failed the link with
-    // "unable to find library -ladvapi32".
     if std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("windows") {
         println!("cargo:rustc-link-lib=advapi32");
     }

--- a/extensions/fuzzy/build.rs
+++ b/extensions/fuzzy/build.rs
@@ -1,5 +1,10 @@
 fn main() {
-    if cfg!(target_os = "windows") {
+    // Gate on the *build target* OS, not the host: cfg!() in a build script
+    // evaluates against the host, so cross-compiling this crate from a
+    // Windows machine to any other target injected the Windows-only
+    // advapi32 link flag into the target and failed the link with
+    // "unable to find library -ladvapi32".
+    if std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("windows") {
         println!("cargo:rustc-link-lib=advapi32");
     }
 }

--- a/extensions/ipaddr/build.rs
+++ b/extensions/ipaddr/build.rs
@@ -1,9 +1,4 @@
 fn main() {
-    // Gate on the *build target* OS, not the host: cfg!() in a build script
-    // evaluates against the host, so cross-compiling this crate from a
-    // Windows machine to any other target injected the Windows-only
-    // advapi32 link flag into the target and failed the link with
-    // "unable to find library -ladvapi32".
     if std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("windows") {
         println!("cargo:rustc-link-lib=advapi32");
     }

--- a/extensions/ipaddr/build.rs
+++ b/extensions/ipaddr/build.rs
@@ -1,5 +1,10 @@
 fn main() {
-    if cfg!(target_os = "windows") {
+    // Gate on the *build target* OS, not the host: cfg!() in a build script
+    // evaluates against the host, so cross-compiling this crate from a
+    // Windows machine to any other target injected the Windows-only
+    // advapi32 link flag into the target and failed the link with
+    // "unable to find library -ladvapi32".
+    if std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("windows") {
         println!("cargo:rustc-link-lib=advapi32");
     }
 }

--- a/extensions/regexp/build.rs
+++ b/extensions/regexp/build.rs
@@ -1,9 +1,4 @@
 fn main() {
-    // Gate on the *build target* OS, not the host: cfg!() in a build script
-    // evaluates against the host, so cross-compiling this crate from a
-    // Windows machine to any other target injected the Windows-only
-    // advapi32 link flag into the target and failed the link with
-    // "unable to find library -ladvapi32".
     if std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("windows") {
         println!("cargo:rustc-link-lib=advapi32");
     }

--- a/extensions/regexp/build.rs
+++ b/extensions/regexp/build.rs
@@ -1,5 +1,10 @@
 fn main() {
-    if cfg!(target_os = "windows") {
+    // Gate on the *build target* OS, not the host: cfg!() in a build script
+    // evaluates against the host, so cross-compiling this crate from a
+    // Windows machine to any other target injected the Windows-only
+    // advapi32 link flag into the target and failed the link with
+    // "unable to find library -ladvapi32".
+    if std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("windows") {
         println!("cargo:rustc-link-lib=advapi32");
     }
 }


### PR DESCRIPTION
## Summary

`cfg!(target_os = "windows")` inside a build script evaluates against the
**host** triple, not the build target. All seven `extensions/*/build.rs`
files use it to conditionally link `advapi32`, so cross-compiling these
crates **from a Windows machine to any other target** (e.g.
`cargo build --target x86_64-linux-android`) injects the Windows-only
`advapi32` link flag into the target build and fails:

```
ld.lld: error: unable to find library -ladvapi32
error: could not compile turso_ext (lib) due to 1 previous error
```

This currently breaks every Windows-hosted cross build of the extension
crates (observed through `turso_ext` / `turso_sdk_kit` as consumed by
`tauri-plugin-turso` in the readest project).

## Fix

Build scripts must read the **target** OS from the `CARGO_CFG_TARGET_OS`
environment variable (Cargo sets it from the target triple) instead of
`cfg!()`, which tests the host:

```diff
 fn main() {
-    if cfg!(target_os = "windows") {
+    if std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("windows") {
         println!("cargo:rustc-link-lib=advapi32");
     }
 }
```

Native Windows builds are unaffected (host == target). Applied uniformly to
all seven extension build scripts. Note `sdk-kit/build.rs` on main already
resolves target vs host correctly via `CARGO_CFG_WINDOWS` — this aligns the
extension crates with that precedent.

## Verification

On a Windows host with `x86_64-linux-android` installed:

- before: `cargo check --target x86_64-linux-android -p turso_ext` fails at
  link with the error above (the bug fires from the build script, so it hits
  `check` too);
- after: check completes and the target crate builds.

Note `sdk-kit/build.rs` on main already uses `CARGO_CFG_WINDOWS` for the same
host-vs-target distinction — this aligns the extension crates with that
in-repo precedent.