### PR TITLE
core/translate: match PRAGMA names without regard to case

### DIFF
--- a/core/translate/pragma.rs
+++ b/core/translate/pragma.rs
@@ -211,6 +211,17 @@ fn emit_table_list_rows_for_schema(
     }
 }
 
+/// SQLite matches PRAGMA names without regard to case.
+fn parse_pragma_name(name: &str) -> Option<PragmaName> {
+    if let Ok(pragma) = PragmaName::from_str(name) {
+        return Some(pragma);
+    }
+    if name.bytes().any(|b| b.is_ascii_uppercase()) {
+        return PragmaName::from_str(&name.to_ascii_lowercase()).ok();
+    }
+    None
+}
+
 pub fn translate_pragma(
     resolver: &Resolver,
     name: &ast::QualifiedName,
@@ -227,7 +238,7 @@ pub fn translate_pragma(
         return Ok(());
     }
 
-    let Ok(pragma) = PragmaName::from_str(name.name.as_str()) else {
+    let Some(pragma) = parse_pragma_name(name.name.as_str()) else {
         // SQLite silently ignores unknown PRAGMA names.
         return Ok(());
     };

--- a/sqlite/conformance/sqlite-sqltests/pragma-name-case-insensitive.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/pragma-name-case-insensitive.sqltest
@@ -1,0 +1,56 @@
+@database :memory:
+
+# Regression test for https://github.com/tursodatabase/turso/issues/8736
+# SQLite matches PRAGMA names without regard to case, so PRAGMA FOREIGN_KEYS
+# and PRAGMA foreign_keys name the same pragma.
+
+test pragma-uppercase-setter-is-applied {
+    PRAGMA USER_VERSION = 9;
+    PRAGMA user_version;
+}
+expect {
+    9
+}
+
+test pragma-mixed-case-reader-sees-value {
+    PRAGMA user_version = 9;
+    PRAGMA User_Version;
+}
+expect {
+    9
+}
+
+test pragma-lowercase-still-works {
+    PRAGMA user_version = 7;
+    PRAGMA USER_VERSION;
+}
+expect {
+    7
+}
+
+test pragma-uppercase-table-info-returns-columns {
+    CREATE TABLE t1(a);
+    PRAGMA TABLE_INFO(t1);
+}
+expect {
+    0|a||0||0
+}
+
+test pragma-uppercase-foreign-keys-enforces {
+    PRAGMA FOREIGN_KEYS = ON;
+    CREATE TABLE t1(a INTEGER PRIMARY KEY);
+    CREATE TABLE t2(b INTEGER REFERENCES t1(a));
+    INSERT INTO t2 VALUES(999);
+}
+expect error {
+    FOREIGN KEY constraint failed
+}
+
+test unknown-pragma-in-any-case-is-ignored {
+    PRAGMA NOT_A_REAL_PRAGMA = 1;
+    PRAGMA Not_A_Real_Pragma;
+    SELECT 1;
+}
+expect {
+    1
+}


### PR DESCRIPTION
`PRAGMA FOREIGN_KEYS = ON` left foreign keys off, `PRAGMA USER_VERSION = 9` changed nothing, and `PRAGMA TABLE_INFO` returned no rows, because a PRAGMA name was only recognised when written in lower case. Any other spelling fell into the branch that silently ignores unknown pragmas. SQLite matches these names without regard to case.

`PragmaName` derives `EnumString` without `ascii_case_insensitive`, so `PragmaName::from_str` in `translate_pragma` only matched the exact snake_case serialization.

## What changed

`parse_pragma_name` looks the name up as written first, so the usual lower-case spelling stays on the existing allocation-free path, and retries on the lower-cased name only when the input contains an upper-case letter. An unknown name is still silently ignored in any spelling, so the behaviour `pragma-unknown-no-op.sqltest` covers is unchanged.

Using `#[strum(ascii_case_insensitive)]` on the enum would have worked too, but it rewrites every arm to `eq_ignore_ascii_case` and makes the common lower-case lookup a linear scan of string comparisons instead of a match, so I kept the exact lookup first.

## Tests

New `sqlite/conformance/sqlite-sqltests/pragma-name-case-insensitive.sqltest` — 6 cases: upper-case setter applied, mixed-case reader, lower-case still works, `PRAGMA TABLE_INFO` returns the column, `PRAGMA FOREIGN_KEYS = ON` enforces the constraint, and an unknown pragma ignored in three spellings.

RED/GREEN verified: with the fix reverted, 5 of the 6 fail (`unknown-pragma-in-any-case-is-ignored` passes both before and after, as intended):

```
── pragma-uppercase-setter-is-applied
   -9
   +0
── pragma-uppercase-table-info-returns-columns
   -0|a||0||0
── pragma-uppercase-foreign-keys-enforces
   expected error but query succeeded
  1 passed, 5 failed
```

With the fix: 6 passed. Also ran the neighbouring pragma and collation corpora (`sqlite-sqltests/pragma/`, `pragma-unknown-no-op`, `pragma-count-changes`, `pragma_query_only`, `pragma-auto-vacuum-none`, `pragma_vdbe_trace`, `column_name_case`, `collate`) — 328 passed, 0 failed. `cargo fmt --check` clean.

I could not finish a full `cargo clippy --workspace --all-features --all-targets` run on my machine (7 GB RAM); the scoped `clippy -p turso_core --lib` run reported only two pre-existing errors unrelated to this change (dead code in `core/index_method/backing_store.rs` and an unfulfilled lint expectation in `core/json/cache.rs`), both present on unmodified `upstream/main`. Relying on CI for the full gate.

Fixes #8736